### PR TITLE
Fix 'feenox -p' to show pdes line by line.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -86,7 +86,7 @@ for pde in *; do
   if [ -e ${pde}/methods.h ] && [ -e ${pde}/init.c ]; then
 
     echo "#include \"${pde}/methods.h\"" >> methods.h
-    echo "${pde}\\\\n\\" >> available.h
+    echo "${pde}\\n\\" >> available.h
 
     if [ ${first} -eq 0 ]; then
       sep="|"


### PR DESCRIPTION
Small fix on `autogen.sh` in generating `available.h` file to properly display the available pde's.