### PR TITLE
fix various typos

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,7 +30,7 @@
  * split examples by problem type
  * YAML blocks in input file for metadata are allowed (so far they are ignored by FeenoX)
  * `$0` (or `${0}` or `$(1)`) expands to the base name of the main input, i.e. without the `.fee` extension
- * bracketed argumens so ${1}1$(1) is a valid string
+ * bracketed arguments so ${1}1$(1) is a valid string
  * multi-group neutron transport with discrete ordinates ($S_N$ method)
  * mimicked-nodes BCs
  * read mesh fields from VTK files

--- a/Makefile-doc.am
+++ b/Makefile-doc.am
@@ -1,6 +1,6 @@
 SUBDIRS = src doc
 
-# the eps files are neded for the description in texinfo
+# the eps files are needed for the description in texinfo
 dist_doc_DATA = AUTHORS \
                 ChangeLog \
                 TODO \

--- a/README
+++ b/README
@@ -369,7 +369,7 @@ ask in FeenoX’s discussion page.
 
         git clone https://github.com/seamplex/feenox
 
-4.  Boostrap, configure, compile & make
+4.  Bootstrap, configure, compile & make
 
         cd feenox
         ./autogen.sh

--- a/README.markdown
+++ b/README.markdown
@@ -372,7 +372,7 @@ ask in FeenoX’s [discussion page].
     git clone https://github.com/seamplex/feenox
     ```
 
-4.  Boostrap, configure, compile & make
+4.  Bootstrap, configure, compile & make
 
     ``` terminal
     cd feenox

--- a/README4engineers
+++ b/README4engineers
@@ -46,7 +46,7 @@ between the human-friendly problem formulation and the input file FeenoX
 reads. There is no need to give extra settings if the problem does not
 ask for them. Note that since the problem has only one volume, E means
 “the” Young modulus. No need to deal with a map between materials and
-mesh entitites (in this case the mapping is not needed but in
+mesh entities (in this case the mapping is not needed but in
 multi-material problems the mapping is needed indeed). Nothing more,
 nothing less.
 

--- a/README4engineers.markdown
+++ b/README4engineers.markdown
@@ -48,7 +48,7 @@ between the human-friendly problem formulation and the input file FeenoX
 reads. There is no need to give extra settings if the problem does not
 ask for them. Note that since the problem has only one volume, `E` means
 “the” Young modulus. No need to deal with a map between materials and
-mesh entitites (in this case the mapping is not needed but in
+mesh entities (in this case the mapping is not needed but in
 [multi-material problems] the mapping is needed indeed). Nothing more,
 nothing less.
 

--- a/README4engineers.md
+++ b/README4engineers.md
@@ -32,7 +32,7 @@ The latter should show the numerical results. See the [tensile test tutorial](ht
 To fix ideas, let us consider the [NAFEMS LE10 "Thick plate pressure" benchmark](https://www.seamplex.com/feenox/examples/mechanical.html#nafems-le10-thick-plate-pressure-benchmark). @Fig:nafems-le10 shows that there is a one-to-one correspondence between the human-friendly problem formulation and the input file FeenoX reads.
 There is no need to give extra settings if the problem does not ask for them.
 Note that since the problem has only one volume, `E` means "the" Young modulus.
-No need to deal with a map between materials and mesh entitites (in this case the mapping is not needed but in [multi-material problems](https://seamplex.com/feenox/examples/mechanical.html#two-cubes-compressing-each-other) the mapping is needed indeed). Nothing more, nothing less.
+No need to deal with a map between materials and mesh entities (in this case the mapping is not needed but in [multi-material problems](https://seamplex.com/feenox/examples/mechanical.html#two-cubes-compressing-each-other) the mapping is needed indeed). Nothing more, nothing less.
 
 ![The NAFEMS LE10 problem statement and the corresponding FeenoX input](nafems-le10-problem-input.svg){#fig:nafems-le10 width=100% }
 

--- a/README4hackers
+++ b/README4hackers
@@ -90,7 +90,7 @@ Unlike these other FEA tools, FeenoX provides…
 
         usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-          -h, --help         display options and detailed explanations of commmand-line usage
+          -h, --help         display options and detailed explanations of command-line usage
           -v, --version      display brief version information and exit
           -V, --versions     display detailed version information
           --pdes             list the types of PROBLEMs that FeenoX can solve, one per line
@@ -191,7 +191,7 @@ The input file…
 -   understands definitions (nouns) and instructions (verbs). FeenoX has
     an actual instruction pointer that loops over the instruction set
     (there might even be conditional blocks).
--   is simple for simple files (but might get more complicated for mor
+-   is simple for simple files (but might get more complicated for more
     complex problems). Remember Alan Kay’s quote: “simple things should
     be simple and complex things should be possible.”
 
@@ -247,7 +247,7 @@ Gitlab / Gitea)
   [definitions (nouns) and instructions (verbs)]: https://seamplex.com/feenox/doc/sds.html#sec:nouns_verbs
   [conditional blocks]: https://www.seamplex.com/feenox/doc/feenox-manual.html#if
   [simple for simple files]: https://seamplex.com/feenox/doc/sds.html#sec:simple
-  [more complicated for mor complex problems]: https://seamplex.com/feenox/doc/sds.html#sec:complex
+  [more complicated for more complex problems]: https://seamplex.com/feenox/doc/sds.html#sec:complex
   [Alan Kay]: https://en.wikipedia.org/wiki/Alan_Kay
   [“simple things should be simple and complex things should be possible.”]:
     https://www.quora.com/What-is-the-story-behind-Alan-Kay-s-adage-Simple-things-should-be-simple-complex-things-should-be-possible
@@ -265,7 +265,7 @@ How
 
 Feenox is a computational tool designed to be run on Unix servers as a
 part of a cloud-first workflow, optionally involving MPI communication
-among different servers to hande arbitrarily-large problems:
+among different servers to handle arbitrarily-large problems:
 
 Check out the section about invocation in the FeenoX manual.
 

--- a/README4hackers.markdown
+++ b/README4hackers.markdown
@@ -81,7 +81,7 @@ Unlike these other FEA tools, FeenoX provides…
 
   usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-    -h, --help         display options and detailed explanations of commmand-line usage
+    -h, --help         display options and detailed explanations of command-line usage
     -v, --version      display brief version information and exit
     -V, --versions     display detailed version information
     --pdes             list the types of PROBLEMs that FeenoX can solve, one per line
@@ -194,7 +194,7 @@ The [input file][self-explanatory ASCII file]…
 - understands [definitions (nouns) and instructions (verbs)]. FeenoX has
   an actual instruction pointer that loops over the instruction set
   (there might even be [conditional blocks]).
-- is [simple for simple files] (but might get [more complicated for mor
+- is [simple for simple files] (but might get [more complicated for more
   complex problems]). Remember [Alan Kay]’s quote: [“simple things
   should be simple and complex things should be possible.”]
 
@@ -251,7 +251,7 @@ and will not compute things that are not actually needed).
   [definitions (nouns) and instructions (verbs)]: https://seamplex.com/feenox/doc/sds.html#sec:nouns_verbs
   [conditional blocks]: https://www.seamplex.com/feenox/doc/feenox-manual.html#if
   [simple for simple files]: https://seamplex.com/feenox/doc/sds.html#sec:simple
-  [more complicated for mor complex problems]: https://seamplex.com/feenox/doc/sds.html#sec:complex
+  [more complicated for more complex problems]: https://seamplex.com/feenox/doc/sds.html#sec:complex
   [Alan Kay]: https://en.wikipedia.org/wiki/Alan_Kay
   [“simple things should be simple and complex things should be possible.”]:
     https://www.quora.com/What-is-the-story-behind-Alan-Kay-s-adage-Simple-things-should-be-simple-complex-things-should-be-possible
@@ -269,7 +269,7 @@ and will not compute things that are not actually needed).
 
 Feenox is a computational tool designed to be run on Unix servers as a
 part of a [cloud-first] workflow, optionally [involving MPI
-communication among different servers] to hande arbitrarily-large
+communication among different servers] to handle arbitrarily-large
 problems:
 
 Check out the section about [invocation] in the [FeenoX manual].

--- a/README4hackers.md
+++ b/README4hackers.md
@@ -27,7 +27,7 @@ Unlike these other FEA tools, FeenoX provides...
    
    usage: feenox [options] inputfile [replacement arguments] [petsc options]
    
-     -h, --help         display options and detailed explanations of commmand-line usage
+     -h, --help         display options and detailed explanations of command-line usage
      -v, --version      display brief version information and exit
      -V, --versions     display detailed version information
      --pdes             list the types of PROBLEMs that FeenoX can solve, one per line
@@ -106,7 +106,7 @@ The [input file](https://seamplex.com/feenox/doc/sds.html#sec:input)...
  - is Git-traceable ([the mesh is defined in a separate file](https://seamplex.com/feenox/doc/sds.html#sec:input) created by [Gmsh](http://gmsh.info/), which may or may not be tracked)
  - allows the user to enter [algebraic expressions whenever a numerical value is needed](https://seamplex.com/feenox/doc/sds.html#sec:expression) (everything is an expression)
  - understands [definitions (nouns) and instructions (verbs)](https://seamplex.com/feenox/doc/sds.html#sec:nouns_verbs). FeenoX has an actual instruction pointer that loops over the instruction set (there might even be [conditional blocks](https://www.seamplex.com/feenox/doc/feenox-manual.html#if)).
- - is [simple for simple files](https://seamplex.com/feenox/doc/sds.html#sec:simple) (but might get [more complicated for mor complex problems](https://seamplex.com/feenox/doc/sds.html#sec:complex)). Remember [Alan Kay](https://en.wikipedia.org/wiki/Alan_Kay)'s quote: ["simple things should be simple and complex things should be possible."](https://www.quora.com/What-is-the-story-behind-Alan-Kay-s-adage-Simple-things-should-be-simple-complex-things-should-be-possible)
+ - is [simple for simple files](https://seamplex.com/feenox/doc/sds.html#sec:simple) (but might get [more complicated for more complex problems](https://seamplex.com/feenox/doc/sds.html#sec:complex)). Remember [Alan Kay](https://en.wikipedia.org/wiki/Alan_Kay)'s quote: ["simple things should be simple and complex things should be possible."](https://www.quora.com/What-is-the-story-behind-Alan-Kay-s-adage-Simple-things-should-be-simple-complex-things-should-be-possible)
  
  
 Following the Unix rule of silence, [the output is 100% user-defined](https://seamplex.com/feenox/doc/sds.html#sec:output): if there are not explicit output instructions, FeenoX will not write anything. And probably nothing will be computed (because FeenoX is smart and will not compute things that are not actually needed).
@@ -114,7 +114,7 @@ Following the Unix rule of silence, [the output is 100% user-defined](https://se
 
 # How
 
-Feenox is a computational tool designed to be run on Unix servers as a part of a [cloud-first](https://seamplex.com/feenox/doc/sds.html#cloud-first) workflow, optionally [involving MPI communication among different servers](https://seamplex.com/feenox/doc/sds.html#sec:scalability) to hande arbitrarily-large problems:
+Feenox is a computational tool designed to be run on Unix servers as a part of a [cloud-first](https://seamplex.com/feenox/doc/sds.html#cloud-first) workflow, optionally [involving MPI communication among different servers](https://seamplex.com/feenox/doc/sds.html#sec:scalability) to handle arbitrarily-large problems:
 
 :::::: {.only-in-format .html }
 ```{=html}

--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,7 @@
  
 ## Wasora-like stuff
 
- * vector & matrix assignements & DAEs
+ * vector & matrix assignments & DAEs
  * debug mode, line-by-line
    - run `feenox` with an option like `-d` or `--debug` and then present a gdb-like interface with print, and step by step advances
  * trap and handle signit & sigterm
@@ -79,7 +79,7 @@
 ## Nice to have
 
  * add a keyword and command-line argument to set `OMP_NUM_THREADS`
- * logaritmic ranges for `PRINT_FUNCTION`
+ * logarithmic ranges for `PRINT_FUNCTION`
  * default separator after `TEXT` should be space, after numerical should be tab
  * `PRINT_FUNCTION` with `%f` in between arguments (like `PRINT_VECTOR`)
  * `BLAS` 
@@ -137,7 +137,7 @@
 
  * poisson f = 1, eta = 0
  * helmholtz f = 1, eta = 1
- * investigate `dsyrk()` insted of `dgemmv()` https://stackoverflow.com/questions/47013581/blas-matrix-by-matrix-transpose-multiply
+ * investigate `dsyrk()` instead of `dgemmv()` https://stackoverflow.com/questions/47013581/blas-matrix-by-matrix-transpose-multiply
  
 ## Heat
 

--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,7 @@ AX_GCC_BUILTIN(__builtin_expect)
   #AC_CHECK_LIB([readline], [readline],
     #[],
     #AS_IF([test "x${with_readline}" != "xcheck"],
-      #AC_MSG_FAILURE([--with-readline was given, but test for readline libray failed])
+      #AC_MSG_FAILURE([--with-readline was given, but test for readline library failed])
     #)
   #)  
 #])
@@ -132,19 +132,19 @@ AS_IF([test "x${with_sundials}" != "xno"] , [
   AC_CHECK_LIB([sundials_ida], [IDAInit],
     [],
     AS_IF([test "x${with_sundials}" != "xcheck"],
-      AC_MSG_FAILURE([--with-sundials was given, but test for libsundials-dev libray failed])
+      AC_MSG_FAILURE([--with-sundials was given, but test for libsundials-dev library failed])
     )
   )  
   AC_CHECK_HEADER([nvector/nvector_serial.h],
     [],
     AS_IF([test "x${with_sundials}" != "xcheck"],
-      AC_MSG_FAILURE([--with-sundials was given, but test for libsundials-dev libray failed])
+      AC_MSG_FAILURE([--with-sundials was given, but test for libsundials-dev library failed])
     )
   )
   AC_CHECK_LIB([sundials_nvecserial], [N_VNew_Serial],
     [],
     AS_IF([test "x${with_sundials}" != "xcheck"],
-      AC_MSG_FAILURE([--with-sundials was given, but test for libsundials-dev libray failed])
+      AC_MSG_FAILURE([--with-sundials was given, but test for libsundials-dev library failed])
     )  
   )
 ])
@@ -177,7 +177,7 @@ AS_IF([test "x${with_petsc}" != "xno"], [
   AC_ARG_VAR(PETSC_DIR, [location of PETSc installation])
   AC_ARG_VAR(PETSC_ARCH, [PETSc architecture])
 
-  # asume we found it
+  # assume we found it
   petsc_found=1
 
   AC_MSG_CHECKING([for PETSc dir])
@@ -233,7 +233,7 @@ have_slepc="no"
 AS_IF([test "x${have_petsc}" != "xno" -a "x${with_slepc}" != "xno"], [
   AC_ARG_VAR(SLEPC_DIR, [location of SLEPc installation])
 
-  # asume we found it
+  # assume we found it
   slepc_found=1
 
   AC_MSG_CHECKING([for SLEPc dir])

--- a/dist/dsc.sh
+++ b/dist/dsc.sh
@@ -41,6 +41,6 @@ lintian -v -i -I -E --pedantic --profile debian feenox_${version}-1_amd64.buildi
 
 # # check
 # # see https://wiki.ubuntu.com/PbuilderHowto
-# sudo pbuilder create --debootstrapopts --variant=buildd
+# sudo pbuilder create --debootstrapopts --variant=build
 # sudo pbuilder update
 # sudo pbuilder build feenox_${version}-1.dsc

--- a/doc/FAQ.markdown
+++ b/doc/FAQ.markdown
@@ -268,7 +268,7 @@ a free no-fee no-X uniX-like finite-element(ish) computational engineering tool
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
 
@@ -282,7 +282,7 @@ With `-h` it gives more information:
 > feenox.exe -h
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
 

--- a/doc/binary.md
+++ b/doc/binary.md
@@ -35,7 +35,7 @@ a cloud-first free no-fee no-X uniX-like finite-element(ish) computational engin
 
 usage: ./feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   -c, --check        validates if the input file is sane or not

--- a/doc/cantilever.sh
+++ b/doc/cantilever.sh
@@ -4,7 +4,7 @@ rm -f *.dat
 for element in tet4 tet10 hex8 hex20 hex27; do
  for c in $(seq 1 10); do
  
-  # create mesh if not alreay cached
+  # create mesh if not already cached
   mesh=cantilever-${element}-${c}
   if [ ! -e ${mesh}.msh ]; then
     scale=$(echo "PRINT 1/${c}" | feenox -)

--- a/doc/cloud-first.md
+++ b/doc/cloud-first.md
@@ -18,7 +18,7 @@ For instance, to make proper use of the computational resources available in rem
  * design shared network file systems
  * etc.
  
-Instead of having to manually perform this set up each time a calculation is needed, one can automatize the workflow with _ad-hoc_ scripts acting as "thin clients" which would, for instance,
+Instead of having to manually perform this set up each time a calculation is needed, one can automate the workflow with _ad-hoc_ scripts acting as "thin clients" which would, for instance,
 
  * launch and configure the remote computing instances, optionally using containerization technology
  * send the input files needed by the computational tools

--- a/doc/compilation.markdown
+++ b/doc/compilation.markdown
@@ -104,7 +104,7 @@ ask in FeenoX’s [discussion page].
     git clone https://github.com/seamplex/feenox
     ```
 
-4.  Boostrap, configure, compile & make
+4.  Bootstrap, configure, compile & make
 
     ``` terminal
     cd feenox
@@ -203,7 +203,7 @@ or Intel’s `icc` and the newer `icx` can also be used.
 Note that there is no need to have a Fortran nor a C++ compiler to build
 FeenoX. They might be needed to build other dependencies (such as PETSc
 and its dependencies), but not to compile FeenoX if all the dependencies
-are installed from the oeprating system’s package repositories. In case
+are installed from the operating system’s package repositories. In case
 the build toolchain is not already installed, do so with
 
 ``` terminal
@@ -525,7 +525,7 @@ a free no-fee no-X uniX-like finite-element(ish) computational engineering tool
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
 

--- a/doc/compilation.md
+++ b/doc/compilation.md
@@ -36,7 +36,7 @@ In particular, [PETSc](https://petsc.org/release/) (and [SLEPc](https://slepc.up
 FeenoX has one mandatory dependency for run-time execution and the standard build toolchain for compilation. It is written in\ C99 so only a C compiler is needed, although `make` is also required. Free and open source compilers are favored.
 The usual C compiler is `gcc` but `clang` or Intel’s `icc` and the newer `icx` can also be used.
 
-Note that there is no need to have a Fortran nor a C++ compiler to build FeenoX. They might be needed to build other dependencies (such as PETSc and its dependencies), but not to compile FeenoX if all the dependencies are installed from the oeprating system's package repositories. In case the build toolchain is not already installed, do so with
+Note that there is no need to have a Fortran nor a C++ compiler to build FeenoX. They might be needed to build other dependencies (such as PETSc and its dependencies), but not to compile FeenoX if all the dependencies are installed from the operating system's package repositories. In case the build toolchain is not already installed, do so with
 
 ```terminal
 sudo apt-get install gcc make
@@ -253,7 +253,7 @@ a free no-fee no-X uniX-like finite-element(ish) computational engineering tool
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
 

--- a/doc/debian.md
+++ b/doc/debian.md
@@ -32,7 +32,7 @@ a cloud-first free no-fee no-X uniX-like finite-element(ish) computational engin
 
 usage: ./feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   -c, --check        validates if the input file is sane or not

--- a/doc/description.md
+++ b/doc/description.md
@@ -11,12 +11,12 @@ A person can tell if a keyword is a definition or an instruction because the for
     ```{.feenox include="examples/fxy.fee"}
     ```
  
- b. If there is a variable, vector or matrix, it is an instruction: evaluate the expression on the right-hand side and assign it to the varible or vector (or matrix) element indicated in the left-hand side. Strictly speaking, if the variable has not already been defined (and implicit declaration is allowed), then the variable is also defined as well, e.g:
+ b. If there is a variable, vector or matrix, it is an instruction: evaluate the expression on the right-hand side and assign it to the variable or vector (or matrix) element indicated in the left-hand side. Strictly speaking, if the variable has not already been defined (and implicit declaration is allowed), then the variable is also defined as well, e.g:
  
     ```{.feenox include="examples/equal.fee"}
     ```
     
-    There is no need to explicitly define the scalar variable `a` with `VAR` since the first assigment also defines it implicitly (if this is allowed by the keyword `IMPLICIT`).
+    There is no need to explicitly define the scalar variable `a` with `VAR` since the first assignment also defines it implicitly (if this is allowed by the keyword `IMPLICIT`).
 
 
 An input file can define its own variables as needed, such as `my_var` or `flag`. But there are some reserved names that are special in the sense that they either
@@ -55,12 +55,12 @@ The timestep is chosen by the SUNDIALS library in order to keep an estimate of t
 
 
 In the third cae, the type of PDE being solved is given by the keyword `PROBLEM`. Some types of PDEs do support transient problems (such as `thermal`) but some others do not (such as `modal`). See the detailed explanation of each problem type for details. Now the transient problem is handled by the TS framework of the PETSc library.
-In general transient PDEs involve a mesh, material properties, inital conditions, transient boundary conditions, etc. And they create a lot of data since results mean spatial and temporal distributions of one or more scalar fields:
+In general transient PDEs involve a mesh, material properties, initial conditions, transient boundary conditions, etc. And they create a lot of data since results mean spatial and temporal distributions of one or more scalar fields:
 
 ```{.feenox include="examples/transient_pde.fee"}
 ```
 
-PETSc’s TS also honors the `min_dt` and `max_dt` variables, but the time step is controled by the allowed relative error with the special variable `ts_rtol`. Again, see the section of the [Partial Differential Equations subsystem] for more information. 
+PETSc’s TS also honors the `min_dt` and `max_dt` variables, but the time step is controlled by the allowed relative error with the special variable `ts_rtol`. Again, see the section of the [Partial Differential Equations subsystem] for more information. 
 
 
 # Algebraic expressions

--- a/doc/differences/README.md
+++ b/doc/differences/README.md
@@ -32,7 +32,7 @@ In order to better illustrate the different approaches proposed by each FEA tool
 ![NAFEMS LE-10 Benchmark problem statement](nafems-le10.png){#fig:nafems-le10}
 
 
-The geometry is defined by two ellipses, namely $(x/2)^2+y^2=1$ and $(x/3.25)^2+(y/2.75)^2=1$. As such, the continuous geometry can be created programatically (and exactly) by a CAD kernel. Since FeenoX better interacts with [Gmsh](http://gmsh.info/), which in turn uses [OpenCASCADE](https://dev.opencascade.org/), it can be easily created using for example the script [`le10-cad.geo`](le10-cad.geo). Other people might want to use an interactive 3D CAD tool to create the continuous geometry.
+The geometry is defined by two ellipses, namely $(x/2)^2+y^2=1$ and $(x/3.25)^2+(y/2.75)^2=1$. As such, the continuous geometry can be created programmatically (and exactly) by a CAD kernel. Since FeenoX better interacts with [Gmsh](http://gmsh.info/), which in turn uses [OpenCASCADE](https://dev.opencascade.org/), it can be easily created using for example the script [`le10-cad.geo`](le10-cad.geo). Other people might want to use an interactive 3D CAD tool to create the continuous geometry.
 
 ![CAD geometry in STEP format created with OpenCASCADE through Gmsh. The tags of the geometrical entities are shown.](le10-tags.svg){#fig:nafems-le10-tags width=70%}
 
@@ -106,11 +106,11 @@ Note that there is no need to define a density.
 <https://cofea.readthedocs.io/en/latest/benchmarks/001-thick-plate/tested-codes.html>
 
 
-### Diferences with FeenoX
+### Differences with FeenoX
 
 [CalculiX](http://www.calculix.de/) reads an input file like FeenoX, but by design it was decided that these files had to be “compatible” with Abaqus’ `.inp` format. The result is that the input files are clotted up with mesh data because the loads have to be given node-wise, so
 
-  1. A particular pre-processor (such as ccg, PrePoMax or FreeCAD) is needed to compute the nodal contributions of the external laods.
+  1. A particular pre-processor (such as ccg, PrePoMax or FreeCAD) is needed to compute the nodal contributions of the external loads.
   2. If the pressure changes from 1 to 2 then the pre-processor has to be re-run.
   3. The input files cannot be Git-tracked.
   4. Simple problems still need complex inputs.

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -1,5 +1,5 @@
 ---
-title: FeenoX documenation directory
+title: FeenoX documentation directory
 language: en-US
 ---
 

--- a/doc/double-click.md
+++ b/doc/double-click.md
@@ -15,7 +15,7 @@ a free no-fee no-X uniX-like finite-element(ish) computational engineering tool
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
 
@@ -29,7 +29,7 @@ With `-h` it gives more information:
 > feenox.exe -h
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
 

--- a/doc/double-click.txt
+++ b/doc/double-click.txt
@@ -23,7 +23,7 @@ execute it there. Without any arguments it says how to use it:
 
     usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-      -h, --help         display options and detailed explanations of commmand-line usage
+      -h, --help         display options and detailed explanations of command-line usage
       -v, --version      display brief version information and exit
       -V, --versions     display detailed version information
 
@@ -35,7 +35,7 @@ With -h it gives more information:
     > feenox.exe -h
     usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-      -h, --help         display options and detailed explanations of commmand-line usage
+      -h, --help         display options and detailed explanations of command-line usage
       -v, --version      display brief version information and exit
       -V, --versions     display detailed version information
 

--- a/doc/feenox-manual.md
+++ b/doc/feenox-manual.md
@@ -100,7 +100,7 @@ reference-dae-va.md
 ```
 
 
-## Partial Differential Equations subsytem
+## Partial Differential Equations subsystem
 
 ### PDE keywords
 

--- a/doc/feenox.1
+++ b/doc/feenox.1
@@ -207,7 +207,7 @@ by using only parts of them or to conditionally abort the execution
 using \f[CR]IF\f[R] clauses.
 .SS \f[CR]ALIAS\f[R]
 .PP
-Define a scalar alias of an already\-defined indentifier.
+Define a scalar alias of an already\-defined identifier.
 .IP
 .EX
 ALIAS { <new_var_name> IS <existing_object> | <existing_object> AS <new_name> }  
@@ -272,7 +272,7 @@ referenced by the given name.
 .P
 .PD
 The path should be given as a \f[CR]printf\f[R]\-like format string
-followed by the expressions which shuold be evaluated in order to obtain
+followed by the expressions which should be evaluated in order to obtain
 the actual file path.
 The expressions will always be floating\-point expressions, but the
 particular integer specifier \f[CR]%d\f[R] is allowed and internally
@@ -1121,14 +1121,14 @@ of gradients (stresses, heat fluxes, etc.), if applicable.
 If either \f[CR]DETECT_HANGING_NODES\f[R] or
 \f[CR]HANDLE_HANGING_NODES\f[R] are given, an intermediate check for
 nodes without any associated elements will be performed.
-For well\-behaved meshes this check is redundant so by detault it is not
+For well\-behaved meshes this check is redundant so by default it is not
 done (\f[CR]DO_NOT_DETEC_HANGING_NODES\f[R]).
 With \f[CR]DETECT_HANGING_NODES\f[R], FeenoX will report the tag of the
 hanging nodes and stop.
 With \f[CR]HANDLE_HANGING_NODES\f[R], FeenoX will fix those nodes and
 try to solve the problem anyway.
 By default, FeenoX checks that all physical groups referred to in the
-\f[CR]BC\f[R] keywors exists (\f[CR]DETECT_UNRESOLVED_BCS\f[R]).
+\f[CR]BC\f[R] keywords exists (\f[CR]DETECT_UNRESOLVED_BCS\f[R]).
 If \f[CR]ALLOW_UNRESOLVED_BCS\f[R] is given, FeenoX will ignore
 unresolved boundary conditions instead of complaining.
 This is handy when using the same input for different meshes which might
@@ -1304,7 +1304,7 @@ into the output file without any mesh data.
 Depending on the output format, this can be used to avoid repeating data
 and/or creating partial output files which can the be latter assembled
 by post\-processing scripts.
-When targetting the \f[CR].msh\f[R] output format, if
+When targeting the \f[CR].msh\f[R] output format, if
 \f[CR]NO_PHYSICAL_NAMES\f[R] is given then the section that sets the
 actual names of the physical entities is not written.
 .PD 0
@@ -1358,7 +1358,7 @@ pre\-pending a dash, i.e.\ \f[CR]$0\-[$1\-[$2...]].msh\f[R] Otherwise
 the given \f[CR]FILE\f[R] is used.
 If no explicit \f[CR]FORMAT\f[R] is given, the format is read from the
 \f[CR]FILE\f[R] extension.
-When targetting the \f[CR].msh\f[R] output format, if
+When targeting the \f[CR].msh\f[R] output format, if
 \f[CR]NO_PHYSICAL_NAMES\f[R] is given then the section that sets the
 actual names of the physical entities is not written.
 .PD 0
@@ -1661,7 +1661,7 @@ argument\ \f[I]x\f[R] during a transient problem using the difference
 between the value of the signal in the previous time step and the actual
 value divided by the time step\ \f[I]δ\f[R]\f[I]t\f[R] stored in
 \f[CR]dt\f[R].
-The argument\ \f[I]x\f[R] does not neet to be a variable, it can be an
+The argument\ \f[I]x\f[R] does not need to be a variable, it can be an
 expression involving one or more variables that change in time.
 For \f[I]t\f[R] = 0, the return value is zero.
 Unlike the functional \f[CR]derivative\f[R], the full dependence of
@@ -2203,7 +2203,7 @@ triangular_wave(x)
 \ 
 .SS \f[CR]wall_time\f[R]
 .PP
-Returns the time ellapsed since the invocation of FeenoX, in seconds.
+Returns the time elapsed since the invocation of FeenoX, in seconds.
 .IP
 .EX
 wall_time()  

--- a/doc/git.md
+++ b/doc/git.md
@@ -31,7 +31,7 @@ If something goes wrong and you get an error, do not hesitate to ask in FeenoX's
     git clone https://github.com/seamplex/feenox
     ```
 
- 4. Boostrap, configure, compile & make
+ 4. Bootstrap, configure, compile & make
  
     ```terminal
     cd feenox

--- a/doc/help-options-txt.sh
+++ b/doc/help-options-txt.sh
@@ -9,7 +9,7 @@ kws=$(grep "///op+" ${1} | awk '{print $1}' | awk -F+ '{print $2}' | uniq)
 
 for kw in ${kws}; do
 
-  # one singe line
+  # one single line
   left=$(grep "///op+${kw}+option" ${1} | cut -d" " -f2- | pandoc -t plain)
   right=$(grep "///op+${kw}+desc" ${1} | cut -d" " -f2- | sed 's_/\\/_//_' | pandoc -t plain)
   len_left=$(echo ${left} | wc -c)

--- a/doc/include-files.lua
+++ b/doc/include-files.lua
@@ -77,7 +77,7 @@ function transclude (cb)
     end
   end
 
-  --- keep track of level before recusion
+  --- keep track of level before recursion
   local buffer_last_heading_level = last_heading_level
 
   local blocks = List:new()

--- a/doc/integral_over_hex.fee
+++ b/doc/integral_over_hex.fee
@@ -23,9 +23,9 @@ f(x,y,z) = sin(x^3 + y^2 + z)
 vec_f20[i] = f(vec_f20_x[i], vec_f20_y[i], vec_f20_z[i])
 vec_f27[i] = f(vec_f27_x[i], vec_f27_y[i], vec_f27_z[i])
 
-# this line is an assignment, that first defines a variale If0
+# this line is an assignment, that first defines a variable If0
 # and then calls the functional integral three times to perform a
-# "continuous" (in the sense that it is numeric but adapative) triple integration
+# "continuous" (in the sense that it is numeric but adaptive) triple integration
 If0 = integral(integral(integral(f(x,y,z), z, 0, 1), y, 0, 1), x, 0, 1)
 
 # these two lines are instructions, they integrate functions f20 and f27 over

--- a/doc/md2.sh
+++ b/doc/md2.sh
@@ -12,7 +12,7 @@ usage() {
   cat << EOF
 usage: $0 <path_to_md> [ --pdf | --html | --gfm | --plain ] [ --output_dir <dir> ]
  
- The <path_to_md> might or migh not include the extension .md.
+ The <path_to_md> might or might not include the extension .md.
  Default is to convert to HTML (just because it is faster) and to
  write the converted file in the same directory where the input is.
 EOF
@@ -254,7 +254,7 @@ if [ "x${format}" = "x.html" ]; then
   # bootstrap tables
   sed -i 's/<table>/<table class=\"table table-striped table-hover table-sm table-responsive-sm\">/'  ${out} 
 
-  # boostrap/prettydocs blockquotes
+  # bootstrap/prettydocs blockquotes
   sed -i 's/<blockquote>/<blockquote class=\"callout-block callout-blockquote\">/'     ${out} 
 
   # img-fluid

--- a/doc/mechanical-square-temperature.fee
+++ b/doc/mechanical-square-temperature.fee
@@ -25,7 +25,7 @@ FUNCTION E_carbon(temp) INTERPOLATION steffen DATA {
 
 
 # known temperature distribution
-# (we could have read it from an outpout of a thermal problem)
+# (we could have read it from an output of a thermal problem)
 T(x,y) := 200 + 350*y
 
 # Young modulus is the function above evaluated at the local temperature

--- a/doc/mechanical-square-uniform.fee
+++ b/doc/mechanical-square-uniform.fee
@@ -25,7 +25,7 @@ FUNCTION E_carbon(temp) INTERPOLATION steffen DATA {
 
 
 # known temperature distribution
-# (we could have read it from an outpout of a thermal problem)
+# (we could have read it from an output of a thermal problem)
 T(x,y) := 200
 
 # Young modulus is the function above evaluated at the local temperature

--- a/doc/sds.md
+++ b/doc/sds.md
@@ -297,7 +297,7 @@ $ wget https://seamplex.com/feenox/dist/linux/feenox-linux-amd64.tar.gz
 Appendix @sec:download has more details about how to download and compile FeenoX.
 The full online documentation contains a [compilation guide](https://seamplex.com/feenox/doc/compilation.html) with further detailed explanations of each of the steps involved.
 
-All the commands needed to either download a binary executable or to compile from source with customized optimization flags can be automatized.
+All the commands needed to either download a binary executable or to compile from source with customized optimization flags can be automated.
 The repository contains a subdirectory [`dist`](https://github.com/seamplex/feenox/tree/main/dist) with instructions and scripts to build
 
  * source tarballs
@@ -333,7 +333,7 @@ a cloud-first free no-fee no-X uniX-like finite-element(ish) computational engin
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   -c, --check        validates if the input file is sane or not
@@ -1165,7 +1165,7 @@ a cloud-first free no-fee no-X uniX-like finite-element(ish) computational engin
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   --pdes             list the types of PROBLEMs that FeenoX can solve, one per line
@@ -1222,7 +1222,7 @@ The `--help` option gives a more detailed usage:
 $ feenox --help
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   -c, --check        validates if the input file is sane or not
@@ -2268,7 +2268,7 @@ a cloud-first free no-fee no-X uniX-like finite-element(ish) computational engin
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   -c, --check        validates if the input file is sane or not

--- a/doc/tests-list.md
+++ b/doc/tests-list.md
@@ -1,6 +1,6 @@
 The [`tests`](https://github.com/seamplex/feenox/tree/main/tests) directory in the repository has hundreds of
  
- - `grep`-able examples, e.g. to see how to use the keywork [`INTEGRATE`](https://seamplex.com/feenox/doc/feenox-manual.html#integrate), do
+ - `grep`-able examples, e.g. to see how to use the keyword [`INTEGRATE`](https://seamplex.com/feenox/doc/feenox-manual.html#integrate), do
  
   ```terminal
    $ cd tests

--- a/doc/tutorials/000-setup/README.markdown
+++ b/doc/tutorials/000-setup/README.markdown
@@ -98,7 +98,7 @@ a free no-fee no-X uniX-like finite-element(ish) computational engineering tool
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   --pdes             list the types of PROBLEMs that FeenoX can solve, one per line
@@ -155,7 +155,7 @@ a free no-fee no-X uniX-like finite-element(ish) computational engineering tool
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   --pdes             list the types of PROBLEMs that FeenoX can solve, one per line
@@ -164,7 +164,7 @@ Run with --help for further explanations.
 $
 ```
 
-If you get stuck or get an error, plase ask for help in the [Github
+If you get stuck or get an error, please ask for help in the [Github
 discussion page][].
 
   [download]: https://www.seamplex.com/feenox/download.html
@@ -250,7 +250,7 @@ contains at least one error.
 To solve problems involving partial differential equations
 (i.e. elasticity, heat conduction, neutron transport, etc.) FeenoX needs
 a mesh in [Gmsh’s MSH format][]. Any mesher whose output format can be
-converted to `.msh` should work, altough of course the most natural way
+converted to `.msh` should work, although of course the most natural way
 to create these meshes is to use [Gmsh][] itself.
 
 The easiest way to go is to install Gmsh from the `apt` repository:
@@ -279,7 +279,7 @@ Issue tracker : https://gitlab.onelab.info/gmsh/gmsh/issues
 $
 ```
 
-It should be noted that depending on the version of the base opearating
+It should be noted that depending on the version of the base operating
 system, the Gmsh version in the `apt` repository might be old enough so
 as to fail with the examples provided in the tutorials, that are based
 on recent Gmsh versions. If this is the case, as with FeenoX above, you
@@ -328,7 +328,7 @@ $ feenox parallelepiped-mechanical.fee
 $ 
 ```
 
-Don’t worry if you do not undertsand the Gmsh command line. We will work
+Don’t worry if you do not understand the Gmsh command line. We will work
 out the details in the tutorials.
 
   [“Parallelepiped…”]: https://www.seamplex.com/feenox/examples/#parallelepiped-whose-youngs-modulus-is-a-function-of-the-temperature

--- a/doc/tutorials/000-setup/README.md
+++ b/doc/tutorials/000-setup/README.md
@@ -68,7 +68,7 @@ a free no-fee no-X uniX-like finite-element(ish) computational engineering tool
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   --pdes             list the types of PROBLEMs that FeenoX can solve, one per line
@@ -113,7 +113,7 @@ a free no-fee no-X uniX-like finite-element(ish) computational engineering tool
 
 usage: feenox [options] inputfile [replacement arguments] [petsc options]
 
-  -h, --help         display options and detailed explanations of commmand-line usage
+  -h, --help         display options and detailed explanations of command-line usage
   -v, --version      display brief version information and exit
   -V, --versions     display detailed version information
   --pdes             list the types of PROBLEMs that FeenoX can solve, one per line
@@ -122,7 +122,7 @@ Run with --help for further explanations.
 $
 ```
 
-If you get stuck or get an error, plase ask for help in the [Github discussion page](https://github.com/seamplex/feenox/discussions).
+If you get stuck or get an error, please ask for help in the [Github discussion page](https://github.com/seamplex/feenox/discussions).
 
 
 ## Compiling from source
@@ -182,7 +182,7 @@ If any of the lines does not say `ok` but something else, then the code contains
 
 # Gmsh
 
-To solve problems involving partial differential equations (i.e. elasticity, heat conduction, neutron transport, etc.) FeenoX needs a mesh in [Gmsh's MSH format](http://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format). Any mesher whose output format can be converted to `.msh` should work, altough of course the most natural way to create these meshes is to use [Gmsh](http://gmsh.info/) itself.
+To solve problems involving partial differential equations (i.e. elasticity, heat conduction, neutron transport, etc.) FeenoX needs a mesh in [Gmsh's MSH format](http://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format). Any mesher whose output format can be converted to `.msh` should work, although of course the most natural way to create these meshes is to use [Gmsh](http://gmsh.info/) itself.
 
 The easiest way to go is to install Gmsh from the `apt` repository:
 
@@ -210,7 +210,7 @@ Issue tracker : https://gitlab.onelab.info/gmsh/gmsh/issues
 $
 ```
 
-It should be noted that depending on the version of the base opearating system, the Gmsh version in the `apt` repository might be old enough so as to fail with the examples provided in the tutorials, that are based on recent Gmsh versions. If this is the case, as with FeenoX above, you can always [download newer Gmsh binaries](http://gmsh.info/#Download):
+It should be noted that depending on the version of the base operating system, the Gmsh version in the `apt` repository might be old enough so as to fail with the examples provided in the tutorials, that are based on recent Gmsh versions. If this is the case, as with FeenoX above, you can always [download newer Gmsh binaries](http://gmsh.info/#Download):
 
 ```terminal
 $ wget http://gmsh.info/bin/Linux/gmsh-4.10.5-Linux64.tgz
@@ -241,7 +241,7 @@ $ feenox parallelepiped-mechanical.fee
 $ 
 ```
 
-Don't worry if you do not undertsand the Gmsh command line. We will work out the details in the tutorials.
+Don't worry if you do not understand the Gmsh command line. We will work out the details in the tutorials.
 
 
 # Text editor

--- a/doc/tutorials/110-tensile-test/README.markdown
+++ b/doc/tutorials/110-tensile-test/README.markdown
@@ -136,7 +136,7 @@ case…
   3.  [ParaView][]
 
   to obtain the results listed in sec. 2.1. Note that these three tools
-  (and any other tool used throuhgout any of the tutorials, including
+  (and any other tool used throughout any of the tutorials, including
   the operating system is free (as an “free speech”) and open source (as
   in “the source code is available”).
 
@@ -780,7 +780,7 @@ Some notes summarizing the section:
     blackboard) formulation of the problem.
   - Input files are [distributed version control][]-friendly.
 
-  See a more detailed decription (and discussion) about the input in
+  See a more detailed description (and discussion) about the input in
   [section 3 of the Software Design Specification][].
 
 - The mesh `tensile-test.msh` file is the output of [Gmsh][] when
@@ -1029,7 +1029,7 @@ and many others, including of course the operating system
 >     3.  understand
 >
 >     what equations are being solved and how they are being solved
->     withing a digital computer. The most important issue of FeenoX
+>     with a digital computer. The most important issue of FeenoX
 >     being free software, besides the three pints above, is that anyone
 >     can *modify* it to suit their needs and then share those
 >     modifications. Of course most people do not know how to see,

--- a/doc/tutorials/110-tensile-test/README.md
+++ b/doc/tutorials/110-tensile-test/README.md
@@ -49,7 +49,7 @@ This first case...
     3. [ParaView](https://www.paraview.org/)
     
    to obtain the results listed in @sec:expected.
-   Note that these three tools (and any other tool used throuhgout any of the tutorials, including the operating system is free (as an “free speech”) and open source (as in “the source code is available”).
+   Note that these three tools (and any other tool used throughout any of the tutorials, including the operating system is free (as an “free speech”) and open source (as in “the source code is available”).
 
  * We are going to illustrate that [FeenoX](https://www.seamplex.com/feenox/) (and [Gmsh](http://gmsh.info/) and up to some degree, [ParaView](https://www.paraview.org/) as well) works very much like an engineering “transfer function” between one (or more) input files and zero (or more) output files (which might include the terminal):
 
@@ -426,7 +426,7 @@ Some notes summarizing the section:
     - The input file should match as much as possible the paper (or blackboard) formulation of the problem.
     - Input files are [distributed version control](https://en.wikipedia.org/wiki/Distributed_version_control)-friendly.
  
-   See a more detailed decription (and discussion) about the input in [section\ 3 of the Software Design Specification](https://www.seamplex.com/feenox/doc/sds.html#sec:input).
+   See a more detailed description (and discussion) about the input in [section\ 3 of the Software Design Specification](https://www.seamplex.com/feenox/doc/sds.html#sec:input).
  
  * The mesh `tensile-test.msh` file is the output of [Gmsh](http://gmsh.info/) when invoked with the input [`tensile-test.geo`](tensile-test.geo) above. It can be either [version\ 4.1](http://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format) or [2.2](http://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format-version-2-_0028Legacy_0029). It is not part of [FeenoX](https://www.seamplex.com/feenox/) the input file, but referred to by the file name. This allows the input file to be tracked by Git (or any other DVCS).
    
@@ -576,7 +576,7 @@ and many others, including of course the operating system [GNU](https://www.gnu.
 >      2. analyze, and eventually
 >      3. understand
 >
->     what equations are being solved and how they are being solved withing a digital computer. The most important issue of FeenoX being free software, besides the three pints above, is that anyone can _modify_ it to suit their needs and then share those modifications. Of course most people do not know how to see, analyze, understand and/or modify computational source code. But the main key is that these people have the _freedom_ to ask somebody else to do it for them, either gratis or for a fee. This is not the case for other non-free (wrongly called “commercial”) engineering tools, where users do not have the freedom to see what and how the equations are being solved, let alone asking a third party to review them.
+>     what equations are being solved and how they are being solved with a digital computer. The most important issue of FeenoX being free software, besides the three pints above, is that anyone can _modify_ it to suit their needs and then share those modifications. Of course most people do not know how to see, analyze, understand and/or modify computational source code. But the main key is that these people have the _freedom_ to ask somebody else to do it for them, either gratis or for a fee. This is not the case for other non-free (wrongly called “commercial”) engineering tools, where users do not have the freedom to see what and how the equations are being solved, let alone asking a third party to review them.
 >
 >     On the other hand, even though it is true that FeenoX can be executed by anyone without paying any royalty to the owner of the copyright, that does not mean that its usage is completely gratis. These issues still hold:
 >      #. Downloading and executing the tool might incur in expenses such as electricity consumption, network connections, storage capacity, computing power, etc. 

--- a/doc/tutorials/120-mazes/README.markdown
+++ b/doc/tutorials/120-mazes/README.markdown
@@ -181,7 +181,7 @@ Gmsh)</p></figcaption>
         ./dxf2geo maze.dxf 0.1
         ```
 
-    The tutorial directory contains a convenience script to perfom all
+    The tutorial directory contains a convenience script to perform all
     these steps in a single call. Just name your PNG `maze.png` and run
     `./png2geo.sh`.
 
@@ -413,7 +413,7 @@ $$
 PROBLEM laplace 2D
 READ_MESH maze.msh
 
-phi_0(x,y) = 0              # inital condition
+phi_0(x,y) = 0              # initial condition
 end_time = 500              # some end time where we know we reached the steady-state
 alpha = 1e-3                # factor of the time derivative to make it advance faster
 BC start   phi=if(t<1,t,1)  # a ramp from zero to avoid discontinuities with the initial condition

--- a/doc/tutorials/120-mazes/README.md
+++ b/doc/tutorials/120-mazes/README.md
@@ -148,7 +148,7 @@ Bitmapped, meshed and solved mazes.
         ./dxf2geo maze.dxf 0.1
         ```
         
-    The tutorial directory contains a convenience script to perfom all these steps in a single call.
+    The tutorial directory contains a convenience script to perform all these steps in a single call.
     Just name your PNG `maze.png` and run `./png2geo.sh`.
     
     

--- a/doc/tutorials/120-mazes/maze-tran-td.fee
+++ b/doc/tutorials/120-mazes/maze-tran-td.fee
@@ -1,7 +1,7 @@
 PROBLEM laplace 2D
 READ_MESH maze.msh
 
-phi_0(x,y) = 0              # inital condition
+phi_0(x,y) = 0              # initial condition
 end_time = 500              # some end time where we know we reached the steady-state
 alpha = 1e-3                # factor of the time derivative to make it advance faster
 BC start   phi=if(t<1,t,1)  # a ramp from zero to avoid discontinuities with the initial condition

--- a/doc/tutorials/210-input-expressions-args.md
+++ b/doc/tutorials/210-input-expressions-args.md
@@ -46,7 +46,7 @@ $
 
 # Mathematical expressions
 
-These examples show how algebraic expressions work in wasora, which is basically as they should. The basic operators are composed by the four basic operations +, -, * and / plus the exponentation operator ^. Parenthesis also work as expected, and can be nested up to any level. Other operators such as comparisons and logicals are introduced in other examples.
+These examples show how algebraic expressions work in wasora, which is basically as they should. The basic operators are composed by the four basic operations +, -, * and / plus the exponentiation operator ^. Parenthesis also work as expected, and can be nested up to any level. Other operators such as comparisons and logicals are introduced in other examples.
 
 
 Expressions works as expected. If you find one case where they do not, please report it to the author of wasora.

--- a/doc/tutorials/220-static-transient.md
+++ b/doc/tutorials/220-static-transient.md
@@ -24,7 +24,7 @@ tau = 1.234
 r = 0
 r[a:b] = 1
 
-# signal y is equal to signal r fitered through a lag
+# signal y is equal to signal r filtered through a lag
 # of characteristic time tau
 y = lag(r, tau)
 

--- a/doc/tutorials/320-thermal/README.markdown
+++ b/doc/tutorials/320-thermal/README.markdown
@@ -859,7 +859,7 @@ the PETSc options `--snes_test_jacobian` and, for smaller problems,
 `--snes_test_jacobian_view`. Note that these options render the
 execution far slower, so make sure the mesh is coarse.
 
-The solver options can be changed at runtime either using keywors in the
+The solver options can be changed at runtime either using keywords in the
 [`PROBLEM`][] definition or command-line options:
 
 - `NONLINEAR_SOLVER newtonls` or `--snes_type=newtonls`
@@ -930,7 +930,7 @@ BC left q=1200     # prescribed heat flux at x=0
 Tref = 293.15
 
 # for fun: compute the Stefan-Boltzmann from fundamental constants
-h = 6.62606957e-34      # planck's contant [J s]
+h = 6.62606957e-34      # planck's constant [J s]
 c = 299792458           # speed of light in vacuum [m s^(-1)]
 k_b = 1.3806488e-23     # boltzmann constant  [m^2 kg s^(-2) K^(-1)]
 sigma = 2*pi*k_b^4/(h^3*c^2) * integral(1/(t^5*(exp(1/t)-1)), t, 1e-2, infinite)
@@ -1591,7 +1591,7 @@ way of overcoming this issue is to go the other way round: make sure the
 boundary conditions match the initial condition at the boundaries for
 $t=0$ and then “quickly” move the boundary condition to the actual
 value. For example, if the condition was $T(1)=1$ instead of $T(1)=0$
-and we blindy wrote
+and we blindly wrote
 
 ``` feenox
 PROBLEM thermal 1d
@@ -1643,7 +1643,7 @@ SOLVE_PROBLEM
 PRINT %.4f t dt %.6f T(1/2)
 ```
 
-we get the right answer, paying some inital cost as small time steps:
+we get the right answer, paying some initial cost as small time steps:
 
 ``` terminal
 $ feenox slab-uniform-transient-from-zero-one-smart.fee 
@@ -1837,7 +1837,7 @@ DEFAULT_ARGUMENT_VALUE 1 1  # no extra args means $1=1
 FUNCTION Tint(t) FILE valve-internal-$1.csv INTERPOLATION linear
 
 # the vector vec_Tint_t has all the times in the file
-# so vecmax() gives the last definiton time
+# so vecmax() gives the last definition time
 end_time = vecmax(vec_Tint_t)
 
 BC internal  T=Tint(t)

--- a/doc/tutorials/320-thermal/README.md
+++ b/doc/tutorials/320-thermal/README.md
@@ -472,7 +472,7 @@ Even more, the most-widely scheme used to solve the non-linear equation $\mathb
 
 The matrix $J = \mathbf{F}^{\prime}$ associated with the linear solve step (which changes from iteration to iteration) is called the jacobian matrix. FeenoX builds an appropriate jacobian for each type of non-linearity, ensuring the convergence is as fast as possible. Advanced users might investigate that indeed $J(\mathbf{u})$ is correct by using the PETSc options `--snes_test_jacobian` and, for smaller problems, `--snes_test_jacobian_view`. Note that these options render the execution far slower, so make sure the mesh is coarse.
 
-The solver options can be changed at runtime either using keywors in the [`PROBLEM`](https://www.seamplex.com/feenox/doc/feenox-manual.html#problem) definition or command-line options:
+The solver options can be changed at runtime either using keywords in the [`PROBLEM`](https://www.seamplex.com/feenox/doc/feenox-manual.html#problem) definition or command-line options:
 
  * `NONLINEAR_SOLVER newtonls` or `--snes_type=newtonls`
  * `LINEAR_SOLVER gmres` or `--ksp_type=gmres`
@@ -902,7 +902,7 @@ $
 
 If the initial condition does not satisfy the Dirichlet boundary conditions, the solver might struggle to converge for small times.
 One way of overcoming this issue is to go the other way round: make sure the boundary conditions match the initial condition at the boundaries for $t=0$ and then "quickly" move the boundary condition to the actual value.
-For example, if the condition was $T(1)=1$ instead of $T(1)=0$ and we blindy wrote
+For example, if the condition was $T(1)=1$ instead of $T(1)=0$ and we blindly wrote
 
 ```{.feenox include="slab-uniform-transient-from-zero-one-naive.fee"}
 ```
@@ -930,7 +930,7 @@ But if we do this instead
 ```{.feenox include="slab-uniform-transient-from-zero-one-smart.fee"}
 ```
 
-we get the right answer, paying some inital cost as small time steps:
+we get the right answer, paying some initial cost as small time steps:
 
 ```terminal
 $ feenox slab-uniform-transient-from-zero-one-smart.fee 

--- a/doc/tutorials/320-thermal/radiation-as-heatflux-kelvin.fee
+++ b/doc/tutorials/320-thermal/radiation-as-heatflux-kelvin.fee
@@ -8,7 +8,7 @@ BC left q=1200     # prescribed heat flux at x=0
 Tref = 293.15
 
 # for fun: compute the Stefan-Boltzmann from fundamental constants
-h = 6.62606957e-34      # planck's contant [J s]
+h = 6.62606957e-34      # planck's constant [J s]
 c = 299792458           # speed of light in vacuum [m s^(-1)]
 k_b = 1.3806488e-23     # boltzmann constant  [m^2 kg s^(-2) K^(-1)]
 sigma = 2*pi*k_b^4/(h^3*c^2) * integral(1/(t^5*(exp(1/t)-1)), t, 1e-2, infinite)

--- a/doc/tutorials/320-thermal/valve.fee
+++ b/doc/tutorials/320-thermal/valve.fee
@@ -6,7 +6,7 @@ DEFAULT_ARGUMENT_VALUE 1 1  # no extra args means $1=1
 FUNCTION Tint(t) FILE valve-internal-$1.csv INTERPOLATION linear
 
 # the vector vec_Tint_t has all the times in the file
-# so vecmax() gives the last definiton time
+# so vecmax() gives the last definition time
 end_time = vecmax(vec_Tint_t)
 
 BC internal  T=Tint(t)

--- a/doc/wire.fee
+++ b/doc/wire.fee
@@ -2,7 +2,7 @@
 # see https://www.seamplex.com/docs/alambre.pdf (in Spanish)
 # (note that there is a systematic error of a factor of two in the measured values)
 # see https://www.seamplex.com/feenox/examples/modal.html#five-natural-modes-of-a-cantilevered-wire
-# for a slighly more complex example
+# for a slightly more complex example
 
 # wire geometry
 l = 0.5*303e-3   # [ m ] cantilever length

--- a/download.md
+++ b/download.md
@@ -25,7 +25,7 @@ toc: true
 > <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/kD3tQdq17ZE?rel=0" allowfullscreen></iframe>
 > :::::
 >
-> Any contribution to make dekstop GUIs such as [PrePoMax](https://prepomax.fs.um.si/) or [FreeCAD](http://https://www.freecadweb.org) to work with FeenoX are welcome.
+> Any contribution to make desktop GUIs such as [PrePoMax](https://prepomax.fs.um.si/) or [FreeCAD](http://https://www.freecadweb.org) to work with FeenoX are welcome.
 
 
 

--- a/examples/README.markdown
+++ b/examples/README.markdown
@@ -36,7 +36,7 @@ The FeenoX examples are divided by the type of problem they solve:
 >   - cell-level neutronics (i.e. method of characteristics, collision
 >     probabilities, etc)
 
-All the files needed to run theses examples are available in the
+All the files needed to run these examples are available in the
 [examples] directory of the [Git repository] and any of the [tarballs],
 both [source] and [binary].
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,7 @@ The FeenoX examples are divided by the type of problem they solve:
 >    - non-linear elasticity
 >    - cell-level neutronics (i.e. method of characteristics, collision probabilities, etc)
  
-All the files needed to run theses examples are available in the [examples](https://github.com/seamplex/feenox/tree/main/examples) directory of the [Git repository](https://github.com/seamplex/feenox) and any of the [tarballs](https://www.seamplex.com/feenox/download.html), both [source](https://www.seamplex.com/feenox/dist/src) and [binary](https://www.seamplex.com/feenox/dist/linux).
+All the files needed to run these examples are available in the [examples](https://github.com/seamplex/feenox/tree/main/examples) directory of the [Git repository](https://github.com/seamplex/feenox) and any of the [tarballs](https://www.seamplex.com/feenox/download.html), both [source](https://www.seamplex.com/feenox/dist/src) and [binary](https://www.seamplex.com/feenox/dist/linux).
 
 For a presentation of these examples, see the "FeenoX Overview Presentation" (August 2021).
 

--- a/examples/basic.markdown
+++ b/examples/basic.markdown
@@ -128,7 +128,7 @@ piapprox[2] = 4*atan(1)
 # the abscissae x where tan(x) = 0 in the range [3:3.5]
 piapprox[3] = root(tan(x), x, 3, 3.5)
 
-# the square of the numerical integral of the guassian curve 
+# the square of the numerical integral of the gaussian curve 
 piapprox[4] = integral(exp(-x^2), x, -10, 10)^2
 
 # the numerical integral of a circle inscribed in a unit square

--- a/examples/basic.md
+++ b/examples/basic.md
@@ -102,7 +102,7 @@ piapprox[2] = 4*atan(1)
 # the abscissae x where tan(x) = 0 in the range [3:3.5]
 piapprox[3] = root(tan(x), x, 3, 3.5)
 
-# the square of the numerical integral of the guassian curve 
+# the square of the numerical integral of the gaussian curve 
 piapprox[4] = integral(exp(-x^2), x, -10, 10)^2
 
 # the numerical integral of a circle inscribed in a unit square

--- a/examples/boiling-2010-eta.fee
+++ b/examples/boiling-2010-eta.fee
@@ -222,7 +222,7 @@ ENDIF
 ##############################
 # output results
 ##############################
-# write information (commented out) in the ouput header
+# write information (commented out) in the output header
 IF in_static
  PRINT "\# vertical boiling channel with uniform power (eta formulation 2010)"
  PRINT "\# Npch = "   Npch

--- a/examples/boiling-2010.fee
+++ b/examples/boiling-2010.fee
@@ -130,7 +130,7 @@ ENDIF
 ##############################
 # output results
 ##############################
-# write information (commented out) in the ouput header
+# write information (commented out) in the output header
 IF in_static
  PRINT "\# vertical boiling channel with uniform power (original formulation 2010)"
  PRINT "\# Npch = "   Npch

--- a/examples/boiling-2012-arbitrary.fee
+++ b/examples/boiling-2012-arbitrary.fee
@@ -1,4 +1,4 @@
-# arbitray normalized interpolated power profile
+# arbitrary normalized interpolated power profile
 FUNCTION potencia(z) INTERPOLATION splines DATA {
 0      0
 0.2    2.5 

--- a/examples/boiling-2012-transient.was
+++ b/examples/boiling-2012-transient.was
@@ -123,7 +123,7 @@ ENDIF
 0 = hi_dot
 0 = Eu_dot
 
-# write information (commented out) in the ouput header
+# write information (commented out) in the output header
 IF in_static
  PRINT TEXT "\# vertical boiling channel"
  PRINT TEXT "\# Npch = "  Npch

--- a/examples/boiling-2012.fee
+++ b/examples/boiling-2012.fee
@@ -239,7 +239,7 @@ ENDIF
 ##############################
 # output results
 ##############################
-# write information (commented out) in the ouput header
+# write information (commented out) in the output header
 IF in_static
  PRINT TEXT "\# vertical boiling channel with arbitrary power: $(1) (2012)"
  PRINT TEXT "\# Npch = "   Npch

--- a/examples/cantilever.fee
+++ b/examples/cantilever.fee
@@ -5,7 +5,7 @@ intro: |
  
   If an external loop successively calls FeenoX with extra command-line arguments, a parametric run is obtained.
   This file `cantilever.fee` fixes the face called "left" and sets a load in the negative\ $z$ direction
-  of a mesh called `cantilever-$1-$2.msh`, where `$1` is the first argument after the inpt file and `$2` the second one.
+  of a mesh called `cantilever-$1-$2.msh`, where `$1` is the first argument after the input file and `$2` the second one.
   The output is a single line containing the number of nodes of the mesh and the displacement in the
   vertical direction\ $w(500,0,0)$ at the center of the cantilever's free face.
  

--- a/examples/cantilever.sh
+++ b/examples/cantilever.sh
@@ -4,7 +4,7 @@ rm -f *.dat
 for element in tet4 tet10 hex8 hex20 hex27; do
  for c in $(seq 1 10); do
  
-  # create mesh if not alreay cached
+  # create mesh if not already cached
   mesh=cantilever-${element}-${c}
   if [ ! -e ${mesh}.msh ]; then
     scale=$(echo "PRINT 1/${c}" | feenox -)

--- a/examples/daes.markdown
+++ b/examples/daes.markdown
@@ -57,7 +57,7 @@ $$
 and $\sigma=10$, $r=28$ and $b=8/3$, which are the classical parameters
 that generate the butterfly as presented by Edward Lorenz back in his
 seminal 1963 paper [Deterministic non-periodic flow]. This example’s
-input file ressembles the parameters, inital conditions and differential
+input file ressembles the parameters, initial conditions and differential
 equations of the problem as naturally as possible with an ASCII file.
 
 ``` feenox
@@ -277,7 +277,7 @@ l1 = 0.3
 l2 = 0.25
 g = 9.8
 
-# inital conditions
+# initial conditions
 theta1_0 = pi/2
 theta2_0 = pi
 
@@ -517,7 +517,7 @@ ENDIF
 ##############################
 # output results
 ##############################
-# write information (commented out) in the ouput header
+# write information (commented out) in the output header
 IF in_static
  PRINT "\# vertical boiling channel with uniform power (eta formulation 2010)"
  PRINT "\# Npch = "   Npch
@@ -667,7 +667,7 @@ where
     3.  `arbitrary`
 
         ``` feenox
-        # arbitray normalized interpolated power profile
+        # arbitrary normalized interpolated power profile
         FUNCTION potencia(z) INTERPOLATION splines DATA {
         0      0
         0.2    2.5 
@@ -844,7 +844,7 @@ ENDIF
 ##############################
 # output results
 ##############################
-# write information (commented out) in the ouput header
+# write information (commented out) in the output header
 IF in_static
  PRINT TEXT "\# vertical boiling channel with arbitrary power: $(1) (2012)"
  PRINT TEXT "\# Npch = "   Npch

--- a/examples/daes.md
+++ b/examples/daes.md
@@ -32,7 +32,7 @@ and $\sigma=10$, $r=28$ and $b=8/3$, which are the classical parameters
 that generate the butterfly as presented by Edward Lorenz back in his
 seminal 1963 paper [Deterministic non-periodic
 flow](http://journals.ametsoc.org/doi/abs/10.1175/1520-0469%281963%29020%3C0130%3ADNF%3E2.0.CO%3B2).
-This example's input file ressembles the parameters, inital conditions
+This example's input file ressembles the parameters, initial conditions
 and differential equations of the problem as naturally as possible with
 an ASCII file.
 
@@ -253,7 +253,7 @@ l1 = 0.3
 l2 = 0.25
 g = 9.8
 
-# inital conditions
+# initial conditions
 theta1_0 = pi/2
 theta2_0 = pi
 
@@ -494,7 +494,7 @@ ENDIF
 ##############################
 # output results
 ##############################
-# write information (commented out) in the ouput header
+# write information (commented out) in the output header
 IF in_static
  PRINT "\# vertical boiling channel with uniform power (eta formulation 2010)"
  PRINT "\# Npch = "   Npch
@@ -632,7 +632,7 @@ where
     c.  `arbitrary`
 
         ``` feenox
-        # arbitray normalized interpolated power profile
+        # arbitrary normalized interpolated power profile
         FUNCTION potencia(z) INTERPOLATION splines DATA {
         0      0
         0.2    2.5 
@@ -810,7 +810,7 @@ ENDIF
 ##############################
 # output results
 ##############################
-# write information (commented out) in the ouput header
+# write information (commented out) in the output header
 IF in_static
  PRINT TEXT "\# vertical boiling channel with arbitrary power: $(1) (2012)"
  PRINT TEXT "\# Npch = "   Npch

--- a/examples/double-pendulum.fee
+++ b/examples/double-pendulum.fee
@@ -10,7 +10,7 @@ l1 = 0.3
 l2 = 0.25
 g = 9.8
 
-# inital conditions
+# initial conditions
 theta1_0 = pi/2
 theta2_0 = pi
 

--- a/examples/double.fee
+++ b/examples/double.fee
@@ -110,7 +110,7 @@ l1 = 0.3
 l2 = 0.25
 g = 9.8
 
-# inital conditions
+# initial conditions
 theta1_0 = pi/2
 theta2_0 = pi
 

--- a/examples/fork.fee
+++ b/examples/fork.fee
@@ -13,7 +13,7 @@ intro: |
   The FeenoX input is extremely simple input file, since it has to solve the free-free mechanical modal
   problem (i.e. without any Dirichlet boundary condition). All it has to do is to print the fundamental frequency.
  
-  To find the length\ $\ell_1$, FeenoX is sucessively called from a Python driving script
+  To find the length\ $\ell_1$, FeenoX is successively called from a Python driving script
   called [`fork.py`](https://github.com/seamplex/feenox/blob/main/examples/fork.py). This script
   uses Gmsh's Python API to create the CAD and the mesh of the tuning fork given the geometrical
   arguments $r$, $w$, $\ell_1$ and $\ell_2$. The parameter $n$ controls the number of elements through

--- a/examples/iaea-2dpwr.fee
+++ b/examples/iaea-2dpwr.fee
@@ -36,7 +36,7 @@ terminal: |
 #           2. Two-dimensional (x,y)-geometry
 #
 PROBLEM neutron_diffusion 2D GROUPS 2
-DEFAULT_ARGUMENT_VALUE 1 quarter   # either quarter or eigth
+DEFAULT_ARGUMENT_VALUE 1 quarter   # either quarter or eighth
 READ_MESH iaea-2dpwr-$1.msh
 
 # define materials and cross sections according to the two-group constants

--- a/examples/laplace.markdown
+++ b/examples/laplace.markdown
@@ -91,7 +91,7 @@ instead.
 PROBLEM laplace 2D
 READ_MESH maze.msh
 
-phi_0(x,y) = 0              # inital condition
+phi_0(x,y) = 0              # initial condition
 end_time = 100              # some end time where we know we reached the steady-state
 alpha = 1e-6                # factor of the time derivative to make it advance faster
 BC start   phi=if(t<1,t,1)  # a ramp from zero to avoid discontinuities with the initial condition

--- a/examples/laplace.md
+++ b/examples/laplace.md
@@ -78,7 +78,7 @@ instead.
 PROBLEM laplace 2D
 READ_MESH maze.msh
 
-phi_0(x,y) = 0              # inital condition
+phi_0(x,y) = 0              # initial condition
 end_time = 100              # some end time where we know we reached the steady-state
 alpha = 1e-6                # factor of the time derivative to make it advance faster
 BC start   phi=if(t<1,t,1)  # a ramp from zero to avoid discontinuities with the initial condition

--- a/examples/lorenz.fee
+++ b/examples/lorenz.fee
@@ -27,7 +27,7 @@ intro: |
   that generate the butterfly as presented by Edward Lorenz back in his
   seminal 1963 paper [Deterministic non-periodic
   flow](http://journals.ametsoc.org/doi/abs/10.1175/1520-0469%281963%29020%3C0130%3ADNF%3E2.0.CO%3B2).
-  This example's input file ressembles the parameters, inital
+  This example's input file ressembles the parameters, initial
   conditions and differential equations of the problem as naturally as
   possible with an ASCII file.
 ...

--- a/examples/maze-tran-td.fee
+++ b/examples/maze-tran-td.fee
@@ -30,7 +30,7 @@ terminal: |
 PROBLEM laplace 2D
 READ_MESH maze.msh
 
-phi_0(x,y) = 0              # inital condition
+phi_0(x,y) = 0              # initial condition
 end_time = 100              # some end time where we know we reached the steady-state
 alpha = 1e-6                # factor of the time derivative to make it advance faster
 BC start   phi=if(t<1,t,1)  # a ramp from zero to avoid discontinuities with the initial condition

--- a/examples/mechanical-square-temperature.fee
+++ b/examples/mechanical-square-temperature.fee
@@ -9,7 +9,7 @@ intro: |
   
   Actually, this example shows three cases:
  
-   1. Uniform temperature indentically equal to 200ºC
+   1. Uniform temperature identically equal to 200ºC
    2. Linear temperature profile on the vertical direction given by an algebraic expression
  
       $$

--- a/examples/mechanical.markdown
+++ b/examples/mechanical.markdown
@@ -246,7 +246,7 @@ If an external loop successively calls FeenoX with extra command-line
 arguments, a parametric run is obtained. This file `cantilever.fee`
 fixes the face called “left” and sets a load in the negative $z$
 direction of a mesh called `cantilever-$1-$2.msh`, where `$1` is the
-first argument after the inpt file and `$2` the second one. The output
+first argument after the input file and `$2` the second one. The output
 is a single line containing the number of nodes of the mesh and the
 displacement in the vertical direction $w(500,0,0)$ at the center of the
 cantilever’s free face.
@@ -302,7 +302,7 @@ rm -f *.dat
 for element in tet4 tet10 hex8 hex20 hex27; do
  for c in $(seq 1 10); do
  
-  # create mesh if not alreay cached
+  # create mesh if not already cached
   mesh=cantilever-${element}-${c}
   if [ ! -e ${mesh}.msh ]; then
     scale=$(echo "PRINT 1/${c}" | feenox -)
@@ -793,7 +793,7 @@ of material properties, interpolated using a [monotonic cubic scheme].
 
 Actually, this example shows three cases:
 
-1.  Uniform temperature indentically equal to 200ºC
+1.  Uniform temperature identically equal to 200ºC
 
 2.  Linear temperature profile on the vertical direction given by an
     algebraic expression

--- a/examples/mechanical.md
+++ b/examples/mechanical.md
@@ -204,7 +204,7 @@ If an external loop successively calls FeenoX with extra command-line
 arguments, a parametric run is obtained. This file `cantilever.fee`
 fixes the face called "left" and sets a load in the negative $z$
 direction of a mesh called `cantilever-$1-$2.msh`, where `$1` is the
-first argument after the inpt file and `$2` the second one. The output
+first argument after the input file and `$2` the second one. The output
 is a single line containing the number of nodes of the mesh and the
 displacement in the vertical direction $w(500,0,0)$ at the center of the
 cantilever's free face.
@@ -267,7 +267,7 @@ rm -f *.dat
 for element in tet4 tet10 hex8 hex20 hex27; do
  for c in $(seq 1 10); do
  
-  # create mesh if not alreay cached
+  # create mesh if not already cached
   mesh=cantilever-${element}-${c}
   if [ ! -e ${mesh}.msh ]; then
     scale=$(echo "PRINT 1/${c}" | feenox -)
@@ -732,7 +732,7 @@ scheme](https://en.wikipedia.org/wiki/Monotone_cubic_interpolation).
 
 Actually, this example shows three cases:
 
-1.  Uniform temperature indentically equal to 200ºC
+1.  Uniform temperature identically equal to 200ºC
 
 2.  Linear temperature profile on the vertical direction given by an
     algebraic expression

--- a/examples/modal.markdown
+++ b/examples/modal.markdown
@@ -30,7 +30,7 @@ the free-free mechanical modal problem (i.e. without any Dirichlet
 boundary condition). All it has to do is to print the fundamental
 frequency.
 
-To find the length $\ell_1$, FeenoX is sucessively called from a Python
+To find the length $\ell_1$, FeenoX is successively called from a Python
 driving script called [`fork.py`]. This script uses Gmsh’s Python API to
 create the CAD and the mesh of the tuning fork given the geometrical
 arguments $r$, $w$, $\ell_1$ and $\ell_2$. The parameter $n$ controls
@@ -190,7 +190,7 @@ PRINT "  \$n\$   |          \$L\$          |       \$\\Gamma\$        |      \$\
 PRINT   ":------:+:---------------------:+:---------------------:+:-------------:+:--------------:"
 PRINT_VECTOR SEP "\t|\t" i "%+.1e" L Gamma "%.4f" mu Mu  
 PRINT
-PRINT ": $2 wire over $1 mesh, participation and excitation factors \$L\$ and \$\\Gamma\$, effective per-mode and cummulative mass fractions \$\\mu\$ and \$M\$"
+PRINT ": $2 wire over $1 mesh, participation and excitation factors \$L\$ and \$\\Gamma\$, effective per-mode and cumulative mass fractions \$\\mu\$ and \$M\$"
 
 # write the modes into a vtk file
 WRITE_MESH wire-$1-$2.vtk \
@@ -252,7 +252,7 @@ $ feenox wire.fee
 9       |       +5.4e-04        |       +9.9e-02        |       0.0134  |       0.6129
 10      |       +2.7e-05        |       +4.9e-03        |       0.0000  |       0.6129
 
-: copper wire over hex mesh, participation and excitation factors $L$ and $\Gamma$, effective per-mode and cummulative mass fractions $\mu$ and $M$
+: copper wire over hex mesh, participation and excitation factors $L$ and $\Gamma$, effective per-mode and cumulative mass fractions $\mu$ and $M$
 $ feenox wire.fee hex copper   | pandoc -o wire-hex-copper.md
 $ feenox wire.fee tet copper   | pandoc -o wire-tet-copper.md
 $ feenox wire.fee hex aluminum | pandoc -o wire-hex-aluminum.md
@@ -283,7 +283,7 @@ copper wire over hex mesh
 | 10  | +5.4e-04 | +9.9e-02 | 0.0134 | 0.6130 |
 
 copper wire over hex mesh, participation and excitation factors $L$ and
-$\Gamma$, effective per-mode and cummulative mass fractions $\mu$ and
+$\Gamma$, effective per-mode and cumulative mass fractions $\mu$ and
 $M$
 
 | $n$ | FEM \[Hz\] | Euler \[Hz\] | Relative difference \[%\] |
@@ -310,7 +310,7 @@ copper wire over tet mesh
 | 10  | -2.2e-04 | -6.9e-02 | 0.0038 | 0.6129 |
 
 copper wire over tet mesh, participation and excitation factors $L$ and
-$\Gamma$, effective per-mode and cummulative mass fractions $\mu$ and
+$\Gamma$, effective per-mode and cumulative mass fractions $\mu$ and
 $M$
 
 | $n$ | FEM \[Hz\] | Euler \[Hz\] | Relative difference \[%\] |
@@ -337,7 +337,7 @@ aluminum wire over hex mesh
 | 10  | -9.5e-06 | -5.2e-03 | 0.0000 | 0.6128 |
 
 aluminum wire over hex mesh, participation and excitation factors $L$
-and $\Gamma$, effective per-mode and cummulative mass fractions $\mu$
+and $\Gamma$, effective per-mode and cumulative mass fractions $\mu$
 and $M$
 
 | $n$ | FEM \[Hz\] | Euler \[Hz\] | Relative difference \[%\] |
@@ -364,7 +364,7 @@ aluminum wire over tet mesh
 | 10  | -7.3e-05 | -6.9e-02 | 0.0038 | 0.6129 |
 
 aluminum wire over tet mesh, participation and excitation factors $L$
-and $\Gamma$, effective per-mode and cummulative mass fractions $\mu$
+and $\Gamma$, effective per-mode and cumulative mass fractions $\mu$
 and $M$
 
   [College]: https://www.ib.edu.ar/

--- a/examples/modal.md
+++ b/examples/modal.md
@@ -21,7 +21,7 @@ the free-free mechanical modal problem (i.e. without any Dirichlet
 boundary condition). All it has to do is to print the fundamental
 frequency.
 
-To find the length $\ell_1$, FeenoX is sucessively called from a Python
+To find the length $\ell_1$, FeenoX is successively called from a Python
 driving script called
 [`fork.py`](https://github.com/seamplex/feenox/blob/main/examples/fork.py).
 This script uses Gmsh's Python API to create the CAD and the mesh of the
@@ -180,7 +180,7 @@ PRINT "  \$n\$   |          \$L\$          |       \$\\Gamma\$        |      \$\
 PRINT   ":------:+:---------------------:+:---------------------:+:-------------:+:--------------:"
 PRINT_VECTOR SEP "\t|\t" i "%+.1e" L Gamma "%.4f" mu Mu  
 PRINT
-PRINT ": $2 wire over $1 mesh, participation and excitation factors \$L\$ and \$\\Gamma\$, effective per-mode and cummulative mass fractions \$\\mu\$ and \$M\$"
+PRINT ": $2 wire over $1 mesh, participation and excitation factors \$L\$ and \$\\Gamma\$, effective per-mode and cumulative mass fractions \$\\mu\$ and \$M\$"
 
 # write the modes into a vtk file
 WRITE_MESH wire-$1-$2.vtk \
@@ -243,7 +243,7 @@ $ feenox wire.fee
 9       |       +5.4e-04        |       +9.9e-02        |       0.0134  |       0.6129
 10      |       +2.7e-05        |       +4.9e-03        |       0.0000  |       0.6129
 
-: copper wire over hex mesh, participation and excitation factors $L$ and $\Gamma$, effective per-mode and cummulative mass fractions $\mu$ and $M$
+: copper wire over hex mesh, participation and excitation factors $L$ and $\Gamma$, effective per-mode and cumulative mass fractions $\mu$ and $M$
 $ feenox wire.fee hex copper   | pandoc -o wire-hex-copper.md
 $ feenox wire.fee tet copper   | pandoc -o wire-tet-copper.md
 $ feenox wire.fee hex aluminum | pandoc -o wire-hex-aluminum.md

--- a/examples/neutron_diffusion.markdown
+++ b/examples/neutron_diffusion.markdown
@@ -44,7 +44,7 @@ alt="The IAEA 2D PWR Benchmark" />
 #           2. Two-dimensional (x,y)-geometry
 #
 PROBLEM neutron_diffusion 2D GROUPS 2
-DEFAULT_ARGUMENT_VALUE 1 quarter   # either quarter or eigth
+DEFAULT_ARGUMENT_VALUE 1 quarter   # either quarter or eighth
 READ_MESH iaea-2dpwr-$1.msh
 
 # define materials and cross sections according to the two-group constants
@@ -449,7 +449,7 @@ We can then compare the numerical $k_\text{eff}$ computed using…
 > monotonically converge to the analytical multiplication factor as
 > $n \rightarrow \infty$ while case ii. will show a XS dilution and
 > smearing effect. FeenoX of course can solve both cases, but there are
-> many other neutronic tools out there that can handle ony structured
+> many other neutronic tools out there that can handle only structured
 > grids.
 
 ``` bash

--- a/examples/neutron_diffusion.md
+++ b/examples/neutron_diffusion.md
@@ -33,7 +33,7 @@ toc: true
 #           2. Two-dimensional (x,y)-geometry
 #
 PROBLEM neutron_diffusion 2D GROUPS 2
-DEFAULT_ARGUMENT_VALUE 1 quarter   # either quarter or eigth
+DEFAULT_ARGUMENT_VALUE 1 quarter   # either quarter or eighth
 READ_MESH iaea-2dpwr-$1.msh
 
 # define materials and cross sections according to the two-group constants
@@ -421,7 +421,7 @@ ii. an uniform grid (mimicking a neutronic code that cannot handle case
 > monotonically converge to the analytical multiplication factor as
 > $n \rightarrow \infty$ while case ii. will show a XS dilution and
 > smearing effect. FeenoX of course can solve both cases, but there are
-> many other neutronic tools out there that can handle ony structured
+> many other neutronic tools out there that can handle only structured
 > grids.
 
 ``` bash

--- a/examples/pi.fee
+++ b/examples/pi.fee
@@ -76,7 +76,7 @@ piapprox[2] = 4*atan(1)
 # the abscissae x where tan(x) = 0 in the range [3:3.5]
 piapprox[3] = root(tan(x), x, 3, 3.5)
 
-# the square of the numerical integral of the guassian curve 
+# the square of the numerical integral of the gaussian curve 
 piapprox[4] = integral(exp(-x^2), x, -10, 10)^2
 
 # the numerical integral of a circle inscribed in a unit square

--- a/examples/thermal.markdown
+++ b/examples/thermal.markdown
@@ -201,7 +201,7 @@ distribution</figcaption>
 
 Say we have two cubes of non-dimensional size $1\times 1 \times 1$, one
 made with a material with unitary properties and the other one whose
-properties depend explicitly ony time. We glue the two cubes together,
+properties depend explicitly on time. We glue the two cubes together,
 fix one side of the unitary material to a fixed zero temperature and set
 a ramp of temperature between zero and one at the opposite end of the
 material with time-varying properties.

--- a/examples/thermal.md
+++ b/examples/thermal.md
@@ -194,7 +194,7 @@ $
 
 Say we have two cubes of non-dimensional size $1\times 1 \times 1$, one
 made with a material with unitary properties and the other one whose
-properties depend explicitly ony time. We glue the two cubes together,
+properties depend explicitly on time. We glue the two cubes together,
 fix one side of the unitary material to a fixed zero temperature and set
 a ramp of temperature between zero and one at the opposite end of the
 material with time-varying properties.

--- a/examples/two-cubes-thermal.fee
+++ b/examples/two-cubes-thermal.fee
@@ -3,7 +3,7 @@ category: thermal
 intro: |
   # Non-dimensional transient heat conduction with time-dependent properties
 
-  Say we have two cubes of non-dimensional size $1\times 1 \times 1$, one made with a material with unitary properties and the other one whose properties depend explicitly ony time. We glue the two cubes together, fix one side of the unitary material to a fixed zero temperature and set a ramp of temperature between zero and one at the opposite end of the material with time-varying properties.
+  Say we have two cubes of non-dimensional size $1\times 1 \times 1$, one made with a material with unitary properties and the other one whose properties depend explicitly on time. We glue the two cubes together, fix one side of the unitary material to a fixed zero temperature and set a ramp of temperature between zero and one at the opposite end of the material with time-varying properties.
   
   This example illustrates how to
  

--- a/examples/two-zone-slab.fee
+++ b/examples/two-zone-slab.fee
@@ -36,7 +36,7 @@ intro: |
  > The objective of this example is to show that
  > case\ i. will monotonically converge to the analytical multiplication factor as $n \rightarrow \infty$ while
  > case\ ii. will show a XS dilution and smearing effect.
- > FeenoX of course can solve both cases, but there are many other neutronic tools out there that can handle ony structured grids.
+ > FeenoX of course can solve both cases, but there are many other neutronic tools out there that can handle only structured grids.
 
  ```{.bash include="two-zone-slab.sh"}
  ```

--- a/examples/wire-hex-aluminum.md
+++ b/examples/wire-hex-aluminum.md
@@ -22,5 +22,5 @@
    10    -9.5e-06   -5.2e-03   0.0000   0.6128
 
   : aluminum wire over hex mesh, participation and excitation factors
-  $L$ and $\Gamma$, effective per-mode and cummulative mass fractions
+  $L$ and $\Gamma$, effective per-mode and cumulative mass fractions
   $\mu$ and $M$

--- a/examples/wire-hex-copper.md
+++ b/examples/wire-hex-copper.md
@@ -22,5 +22,5 @@
    10    +5.4e-04   +9.9e-02   0.0134   0.6130
 
   : copper wire over hex mesh, participation and excitation factors $L$
-  and $\Gamma$, effective per-mode and cummulative mass fractions $\mu$
+  and $\Gamma$, effective per-mode and cumulative mass fractions $\mu$
   and $M$

--- a/examples/wire-tet-aluminum.md
+++ b/examples/wire-tet-aluminum.md
@@ -22,5 +22,5 @@
    10    -7.3e-05   -6.9e-02   0.0038   0.6129
 
   : aluminum wire over tet mesh, participation and excitation factors
-  $L$ and $\Gamma$, effective per-mode and cummulative mass fractions
+  $L$ and $\Gamma$, effective per-mode and cumulative mass fractions
   $\mu$ and $M$

--- a/examples/wire-tet-copper.md
+++ b/examples/wire-tet-copper.md
@@ -22,5 +22,5 @@
    10    -2.2e-04   -6.9e-02   0.0038   0.6129
 
   : copper wire over tet mesh, participation and excitation factors $L$
-  and $\Gamma$, effective per-mode and cummulative mass fractions $\mu$
+  and $\Gamma$, effective per-mode and cumulative mass fractions $\mu$
   and $M$

--- a/examples/wire.fee
+++ b/examples/wire.fee
@@ -53,7 +53,7 @@ terminal: |
   9       |       +5.4e-04        |       +9.9e-02        |       0.0134  |       0.6129
   10      |       +2.7e-05        |       +4.9e-03        |       0.0000  |       0.6129
   
-  : copper wire over hex mesh, participation and excitation factors $L$ and $\Gamma$, effective per-mode and cummulative mass fractions $\mu$ and $M$
+  : copper wire over hex mesh, participation and excitation factors $L$ and $\Gamma$, effective per-mode and cumulative mass fractions $\mu$ and $M$
   $ feenox wire.fee hex copper   | pandoc -o wire-hex-copper.md
   $ feenox wire.fee tet copper   | pandoc -o wire-tet-copper.md
   $ feenox wire.fee hex aluminum | pandoc -o wire-hex-aluminum.md
@@ -113,7 +113,7 @@ PRINT "  \$n\$   |          \$L\$          |       \$\\Gamma\$        |      \$\
 PRINT   ":------:+:---------------------:+:---------------------:+:-------------:+:--------------:"
 PRINT_VECTOR SEP "\t|\t" i "%+.1e" L Gamma "%.4f" mu Mu  
 PRINT
-PRINT ": $2 wire over $1 mesh, participation and excitation factors \$L\$ and \$\\Gamma\$, effective per-mode and cummulative mass fractions \$\\mu\$ and \$M\$"
+PRINT ": $2 wire over $1 mesh, participation and excitation factors \$L\$ and \$\\Gamma\$, effective per-mode and cumulative mass fractions \$\\mu\$ and \$M\$"
 
 # write the modes into a vtk file
 WRITE_MESH wire-$1-$2.vtk \

--- a/src/feenox.h
+++ b/src/feenox.h
@@ -120,7 +120,7 @@ extern "C++" {
 #define BUFFER_TOKEN_SIZE        256
 #define BUFFER_LINE_SIZE        4096
 
-// number of internal functions, functional adn vector functions
+// number of internal functions, functional and vector functions
 #define N_BUILTIN_FUNCTIONS         70
 #define N_BUILTIN_FUNCTIONALS       8
 #define N_BUILTIN_VECTOR_FUNCTIONS  8
@@ -1328,7 +1328,7 @@ struct mesh_t {
   
   unsigned int max_nodes_per_element;
   unsigned int max_faces_per_element;
-  unsigned int max_first_neighbor_nodes;  // to estimate matrix bandwith
+  unsigned int max_first_neighbor_nodes;  // to estimate matrix bandwidth
 
   // kd-trees to make efficient searches
   void *kd_nodes;
@@ -1884,7 +1884,7 @@ struct feenox_t {
 
 #ifdef HAVE_PETSC    
     char *petsc_options;
-    PetscBool pre_allocate;        // preallocate? onyl works for petsc >= 3.19
+    PetscBool pre_allocate;        // preallocate? only works for petsc >= 3.19
     PetscBool allow_new_nonzeros;  // flag to set MAT_NEW_NONZERO_ALLOCATION_ERR to false, needed in some rare cases
     PetscBool petscinit_called;    // flag
 

--- a/src/flow/debug.c
+++ b/src/flow/debug.c
@@ -212,7 +212,7 @@ void wasora_debug(void) {
         argument = debugcommand + strlen(token)+1;
         
         if (wasora_get_next_token(NULL) != NULL && wasora_parse_expression(argument, &wasora.cond_breakpoint) == 0) {
-          fprintf(stderr, "next breakpoint will ocurr whenever '%s' is not zero\n", argument);
+          fprintf(stderr, "next breakpoint will occur whenever '%s' is not zero\n", argument);
         } else {
           wasora_debug_printerror();
           fprintf(stderr, "no breakpoint set\n");

--- a/src/flow/error.c
+++ b/src/flow/error.c
@@ -134,9 +134,9 @@ void feenox_gsl_handler(const char *reason, const char *file_ptr, int line, int 
 void feenox_signal_handler(int sig_num) {
 
   if (feenox.mpi_size != 0) {
-    fprintf(stderr, "pid %d: signal #%d caught, finnishing...\n", getpid(), sig_num);
+    fprintf(stderr, "pid %d: signal #%d caught, finishing...\n", getpid(), sig_num);
   } else {
-    fprintf(stderr, "[%d] pid %d: signal #%d caught, finnishing...\n", feenox.mpi_rank, getpid(), sig_num);
+    fprintf(stderr, "[%d] pid %d: signal #%d caught, finishing...\n", feenox.mpi_rank, getpid(), sig_num);
   }
   fflush(stderr);
 

--- a/src/flow/init.c
+++ b/src/flow/init.c
@@ -457,7 +457,7 @@ int feenox_init_special_objects(void) {
 //va+realtime_scale+desc problem time with realtime, up to a scale given.
 //va+realtime_scale+detail  For example, if the scale is set to one, then
 //va+realtime_scale+detail FeenoX will advance the problem time at the same pace that the real wall time advances. If set to
-//va+realtime_scale+detail two, FeenoX time wil advance twice as fast as real time, and so on. If the calculation time is
+//va+realtime_scale+detail two, FeenoX time will advance twice as fast as real time, and so on. If the calculation time is
 //va+realtime_scale+detail slower than real time modified by the scale, this variable has no effect on the overall behavior
 //va+realtime_scale+detail and execution will proceed as quick as possible with no delays.
 //  feenox_special_var(realtime_scale) = feenox_get_or_define_variable_get_ptr("realtime_scale");

--- a/src/io/shmem.c
+++ b/src/io/shmem.c
@@ -60,7 +60,7 @@ void *wasora_get_shared_pointer(char *name, size_t size) {
     wasora_runtime_error();
   }
   if ((pointer = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)) == MAP_FAILED) {
-    wasora_push_error_message("'%s' maping shared memory object '%s'", strerror(errno), name);
+    wasora_push_error_message("'%s' mapping shared memory object '%s'", strerror(errno), name);
     wasora_runtime_error();
   }
 
@@ -86,7 +86,7 @@ sem_t *wasora_get_semaphore(char *name) {
 
 #if !defined(LD_STATIC)
   if ((dangling_pid = wasora_create_lock(name, 1)) != 0) {
-    wasora_push_error_message("sempahore '%s' is being used by process %d", name, dangling_pid);
+    wasora_push_error_message("semaphore '%s' is being used by process %d", name, dangling_pid);
     wasora_runtime_error();
   }
 

--- a/src/math/builtin_functionals.c
+++ b/src/math/builtin_functionals.c
@@ -124,11 +124,11 @@ double feenox_builtin_derivative(expr_item_t *a, var_t *var_x) {
 ///fu+integral+desc scheme, in which the domain is divided into a number of maximum number
 ///fu+integral+desc of subintervals
 ///fu+integral+desc and a fixed-point Gauss-Kronrod-Patterson scheme is applied to each
-///fu+integral+desc quadrature subinterval. Based on an estimation of the error commited,
+///fu+integral+desc quadrature subinterval. Based on an estimation of the error committed,
 ///fu+integral+desc one or more of these subintervals may be split to repeat
-///fu+integral+desc the numerical integration alogorithm with a refined division.
+///fu+integral+desc the numerical integration algorithm with a refined division.
 ///fu+integral+desc The fifth optional argument $\epsilon$ is is a relative tolerance
-///fu+integral+desc used to check for convergence. It correspondes to GSL's `epsrel` 
+///fu+integral+desc used to check for convergence. It corresponds to GSL's `epsrel` 
 ///fu+integral+desc parameter (`epsabs` is set to zero). 
 ///fu+integral+desc The sixth optional argument $1\leq k \le 6$ is an integer key that
 ///fu+integral+desc indicates the integration rule to apply in each interval.
@@ -227,7 +227,7 @@ double feenox_builtin_integral(expr_item_t *a, var_t *var_x) {
 ///fu+gauss_kronrod+desc 43-point and 87-point integration rules in succession until an
 ///fu+gauss_kronrod+desc estimate of the integral is achieved within the relative tolerance
 ///fu+gauss_kronrod+desc given in the fifth optional argument $\epsilon$
-///fu+gauss_kronrod+desc It correspondes to GSL's `epsrel` parameter (`epsabs` is set to zero).  
+///fu+gauss_kronrod+desc It corresponds to GSL's `epsrel` parameter (`epsabs` is set to zero).  
 ///fu+gauss_kronrod+desc The rules are designed in such a way that each rule uses all
 ///fu+gauss_kronrod+desc the results of its predecessors, in order to minimize the total
 ///fu+gauss_kronrod+desc number of function evaluations.

--- a/src/math/builtin_functions.c
+++ b/src/math/builtin_functions.c
@@ -215,7 +215,7 @@ double feenox_builtin_clock(expr_item_t *f) {
 }
 
 ///fn+wall_time+usage wall_time()
-///fn+wall_time+desc Returns the time ellapsed since the invocation of FeenoX, in seconds.
+///fn+wall_time+desc Returns the time elapsed since the invocation of FeenoX, in seconds.
 double feenox_builtin_wall_time(expr_item_t *f) {
 
 #ifdef HAVE_CLOCK_GETTIME
@@ -384,7 +384,7 @@ double feenox_builtin_last(expr_item_t *f) {
 ///fn+d_dt+desc during a transient problem
 ///fn+d_dt+desc using the difference between the value of the signal in the previous time step
 ///fn+d_dt+desc and the actual value divided by the time step\ $\delta t$ stored in `dt`.
-///fn+d_dt+desc The argument\ $x$ does not neet to be a variable, it can be an expression
+///fn+d_dt+desc The argument\ $x$ does not need to be a variable, it can be an expression
 ///fn+d_dt+desc involving one or more variables that change in time.
 ///fn+d_dt+desc For $t=0$, the return value is zero.
 ///fn+d_dt+desc Unlike the functional `derivative`, the full dependence of these variables with time

--- a/src/math/expressions.c
+++ b/src/math/expressions.c
@@ -175,7 +175,7 @@ int feenox_expression_parse(expr_t *this, const char *orig_string) {
   char last_op = '(';  // initially it is like we start with an opening parenthesis
   size_t level = 1;
   expr_item_t *item;
-  // TODO: maybe we can get away wih half delta_level?
+  // TODO: maybe we can get away with half delta_level?
   size_t delta_level = strlen(operators);
 
   while (*string != '\0') {
@@ -191,7 +191,7 @@ int feenox_expression_parse(expr_t *this, const char *orig_string) {
       // blanks are ignored
       string++;
     } else if ((oper = strchr(operators, *string)) != NULL) {
-      // handle one of the operatos
+      // handle one of the operators
       if (*string == '(') {
         
         level += delta_level;

--- a/src/math/function.c
+++ b/src/math/function.c
@@ -713,7 +713,7 @@ double feenox_function_eval(function_t *this, const double *const_x) {
         double *r = NULL;
         feenox_check_alloc(r = calloc(this->n_arguments, sizeof(double)));
 
-        int flag = 1;  // asume we've been asked a point of the grid
+        int flag = 1;  // assume we've been asked a point of the grid
         unsigned int i = 0;
         for (i = 0; i < this->n_arguments; i++) {
 

--- a/src/mesh/calculix.c
+++ b/src/mesh/calculix.c
@@ -320,7 +320,7 @@ int feenox_mesh_read_frd(mesh_t *this) {
           return WASORA_RUNTIME_ERROR;
         }
         if (type > 13) {
-          feenox_push_error_message("element type '%d' shold be less than 14", type);
+          feenox_push_error_message("element type '%d' should be less than 14", type);
           return WASORA_RUNTIME_ERROR;
         }
         mesh->element[i].type = &(feenox_mesh.element_type[frdfromgmsh_types[type]]);

--- a/src/mesh/extrema.c
+++ b/src/mesh/extrema.c
@@ -69,7 +69,7 @@ int feenox_instruction_mesh_find_extrema(void *arg) {
         }
       } else {
         
-        // unless explcitily asked, check for all nodes, cells and gauss
+        // unless explicitly asked, check for all nodes, cells and gauss
         if (mesh_find_extrema->field_location == field_location_default || mesh_find_extrema->field_location == field_location_cells) {
           
           if (mesh->cell == NULL) {

--- a/src/mesh/geometry.c
+++ b/src/mesh/geometry.c
@@ -136,7 +136,7 @@ int feenox_mesh_compute_outward_normal(element_t *element, double *n) {
     feenox_call(feenox_mesh_compute_element_barycenter(volumetric_neighbor, volumetric_neighbor_center));
 
     // compute the product between the proposed normal and the difference between these two
-    // if the product is positve, invert the normal
+    // if the product is positive, invert the normal
     if (feenox_mesh_subtract_dot(volumetric_neighbor_center, surface_center, n) > 0) {
       n[0] = -n[0];
       n[1] = -n[1];

--- a/src/mesh/gmsh.c
+++ b/src/mesh/gmsh.c
@@ -273,14 +273,14 @@ int feenox_mesh_read_gmsh(mesh_t *this) {
     // ------------------------------------------------------      
     } else if (strncmp("$PartitionedEntities", buffer, 20) == 0) {
       
-      // number of partitions and ghost entitites
+      // number of partitions and ghost entities
       size_t numbers[2] = {0,0};
       feenox_call(feenox_gmsh_read_data_size_t(this, 2, numbers, binary));
       this->num_partitions = numbers[0];
       this->num_ghost_entitites = numbers[1];
       
       if (this->num_ghost_entitites != 0) {
-        feenox_push_error_message("ghost entitites not yet handled");
+        feenox_push_error_message("ghost entities not yet handled");
         return FEENOX_ERROR;
       }
       
@@ -1018,7 +1018,7 @@ int feenox_mesh_write_mesh_gmsh(mesh_t *this, FILE *file, int no_physical_names)
     fprintf(file, "%ld ", this->element[i].tag);
     fprintf(file, "%d ", this->element[i].type->id);
 
-    // in principle we should write the detailed information about groups and partitons
+    // in principle we should write the detailed information about groups and partitions
 //    fprintf(file, "%d ", this->element[i].ntags);
     
     // but for now only two tags are enough:
@@ -1057,7 +1057,7 @@ int feenox_mesh_write_data_gmsh(mesh_write_t *this, mesh_write_dist_t *dist) {
 
   // one string tag
   fprintf(this->file->pointer, "1\n");
-  // the name of the vew
+  // the name of the view
   fprintf(this->file->pointer, "\"%s\"\n", dist->name);
   // the other one (optional) is the interpolation scheme
   

--- a/src/mesh/init.c
+++ b/src/mesh/init.c
@@ -32,7 +32,7 @@ int feenox_mesh_init_special_objects(void) {
   // como ahora hacemos alias de a los elementos del vector x_global lo inicializamos
   feenox_call(feenox_vector_init(feenox.mesh.vars.vec_x, FEENOX_VECTOR_INITIAL));
   
-//va+x+desc Holder variable for spatial dependance of functions, such spatial distribution
+//va+x+desc Holder variable for spatial dependence of functions, such spatial distribution
 //va+x+desc of physical properties or results of partial differential equations.
   feenox_check_null(feenox.mesh.vars.x = feenox_get_or_define_variable_get_ptr("x"));
   feenox_realloc_variable_ptr(feenox.mesh.vars.x, gsl_vector_ptr(feenox_value_ptr(feenox.mesh.vars.vec_x), 0), 0);
@@ -96,7 +96,7 @@ int feenox_mesh_init_special_objects(void) {
   
 //va+mesh_failed_interpolation_factor+desc When interpolating a mesh-defined function, the interpolation point\ $\vec{x}$ seems to fall outside
 //va+mesh_failed_interpolation_factor+desc an element using the $k$-dimensional tree (most efficient), and more robust brute-force approach is taken
-//va+mesh_failed_interpolation_factor+desc less eficient using a radius of size `mesh_failed_interpolation_factor` times the distance between $\vec{x}$
+//va+mesh_failed_interpolation_factor+desc less efficient using a radius of size `mesh_failed_interpolation_factor` times the distance between $\vec{x}$
 //va+mesh_failed_interpolation_factor+desc and the nearest node to \vec{x$} is performed.
 //va+mesh_failed_interpolation_factor+desc If this factor is zero, then the value at the nearest node to $x$ is returned. Default is DEFAULT_MESH_FAILED_INTERPOLATION_FACTOR.
   feenox_check_null(feenox.mesh.vars.mesh_failed_interpolation_factor = feenox_get_or_define_variable_get_ptr("mesh_failed_interpolation_factor"));

--- a/src/mesh/interpolate.c
+++ b/src/mesh/interpolate.c
@@ -116,7 +116,7 @@ int feenox_mesh_interp_solve_for_r(element_t *this, const double *x, double *r) 
     p.element = this;
     p.x = x;
   
-    test = gsl_vector_calloc(this->type->dim);    // guess inicial cero
+    test = gsl_vector_calloc(this->type->dim);    // guess initial cero
 
 //    T = gsl_multiroot_fsolver_hybrids;
 //    T = gsl_multiroot_fsolver_hybrid;      

--- a/src/mesh/material.c
+++ b/src/mesh/material.c
@@ -149,7 +149,7 @@ int feenox_define_property_data(const char *property_name, const char *material_
 property_data_t *feenox_define_property_data_get_ptr(property_t *property, material_t *material, const char *expr_string) {
   // there's a function called material_property with the algebraic
   // expression that depends on x,y,z
-  // if we need to fail, fail befor allocating
+  // if we need to fail, fail before allocating
   if (property == NULL || material == NULL || material->mesh == NULL) {
     feenox_push_error_message("something is null when calling feenox_define_property_data_get_ptr()");
     return NULL;

--- a/src/mesh/mesh.c
+++ b/src/mesh/mesh.c
@@ -218,7 +218,7 @@ int feenox_instruction_mesh_read(void *arg) {
     if ((physical_group->var_volume != NULL && physical_group->var_volume->used) ||
         (physical_group->vector_cog != NULL && physical_group->vector_cog->used)) {
         
-      // TODO: why dont' we use feenox_physical_group_compute_volume()?
+      // TODO: why dont we use feenox_physical_group_compute_volume()?
         
       physical_group->volume = 0;
       physical_group->cog[0] = 0;

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -89,7 +89,7 @@ int feenox_parse_input_file(const char *filepath, int from, int to) {
       }
       
       // the line is broken by strtok inside parse_line() and we need
-      // the original for assignements and equations
+      // the original for assignments and equations
       feenox_check_alloc(feenox_parser.full_line = strdup(feenox_parser.line));
       if (feenox_parse_line() != FEENOX_OK) {
         feenox_free(feenox_parser.full_line);
@@ -163,7 +163,7 @@ int feenox_parse_line(void) {
       return FEENOX_OK;
     
 ///kw+ALIAS+usage ALIAS
-///kw+ALIAS+desc Define a scalar alias of an already-defined indentifier.
+///kw+ALIAS+desc Define a scalar alias of an already-defined identifier.
     } else if (strcasecmp(token, "ALIAS") == 0) {
       feenox_call(feenox_parse_alias());
       return FEENOX_OK;
@@ -1308,7 +1308,7 @@ int feenox_parse_function(void) {
       }
 
 //kw+FUNCTION+usage [ X_INCREASES_FIRST <expr> ]
-//kw+FUNCTION+detail and wether the definition data is sorted with the first argument changing first (`X_INCREASES_FIRST` evaluating to non-zero) or with the last argument changing first (zero).
+//kw+FUNCTION+detail and whether the definition data is sorted with the first argument changing first (`X_INCREASES_FIRST` evaluating to non-zero) or with the last argument changing first (zero).
     } else if (strcasecmp(token,"X_INCREASES_FIRST") == 0) {
 
       feenox_call(feenox_parser_expression(&function->expr_x_increases_first));
@@ -1455,7 +1455,7 @@ int feenox_parse_file(char *default_mode) {
   while ((token = feenox_get_next_token(NULL)) != NULL) {
 ///kw+FILE+usage PATH <format>
 ///kw+FILE+usage expr_1 expr_2 ... expr_n
-///kw+FILE+detail The path should be given as a `printf`-like format string followed by the expressions which shuold be
+///kw+FILE+detail The path should be given as a `printf`-like format string followed by the expressions which should be
 ///kw+FILE+detail evaluated in order to obtain the actual file path. The expressions will always be floating-point expressions,
 ///kw+FILE+detail but the particular integer specifier `%d` is allowed and internally transformed to `%.0f`.
     if (strcasecmp(token, "PATH") == 0) {
@@ -1608,7 +1608,7 @@ int feenox_parse_print(void) {
 ///kw+PRINT+detail If the `FILE` keyword is not provided, default is to write to `stdout`.
     if (strcasecmp(token, "FILE") == 0 || strcasecmp(token, "FILE_PATH") == 0) {
       feenox_call(feenox_parser_file(&print->file));
-      // we don't have the file name becuase it was already consumed by the above call
+      // we don't have the file name because it was already consumed by the above call
       // and we do not expect the PRINT instruction to be used from the API
       // so we directly access the internals of the structure
       if (print->file->mode == NULL) {
@@ -2391,7 +2391,7 @@ int feenox_parse_write_mesh(void) {
       mesh_write->no_mesh = 1;
       
 ///kw_pde+WRITE_MESH+usage [ NO_PHYSICAL_NAMES ]@
-///kw_pde+WRITE_MESH+detail When targetting the `.msh` output format, if `NO_PHYSICAL_NAMES` is given then the
+///kw_pde+WRITE_MESH+detail When targeting the `.msh` output format, if `NO_PHYSICAL_NAMES` is given then the
 ///kw_pde+WRITE_MESH+detail section that sets the actual names of the physical entities is not written.      
 ///kw_pde+WRITE_MESH+detail This might be needed in some cases to avoid name clashes when dealing with multiple `.msh` files.
     } else if (strcasecmp(token, "NO_PHYSICAL_NAMES") == 0) {
@@ -2551,7 +2551,7 @@ int feenox_parse_write_results(void) {
 ///kw_pde+WRITE_RESULTS+usage [ FILE <file> ]@
 ///kw_pde+WRITE_RESULTS+detail If no `FILE` is provided, the output file is the same as the input file replacing the
 ///kw_pde+WRITE_RESULTS+detail `.fee` extension with the format extension, i.e. `$0.msh`.
-///kw_pde+WRITE_RESULTS+detail If there are further optional command line arguments, they are added pre-pending a dash,
+///kw_pde+WRITE_RESULTS+detail If there are further optional command line arguments, they are added prepending a dash,
 ///kw_pde+WRITE_RESULTS+detail i.e. `$0-[$1-[$2...]].msh`
 ///kw_pde+WRITE_RESULTS+detail Otherwise the given `FILE` is used.
 ///kw_pde+WRITE_RESULTS+detail If no explicit `FORMAT` is given, the format is read from the `FILE` extension.
@@ -2561,7 +2561,7 @@ int feenox_parse_write_results(void) {
       }
 
 ///kw_pde+WRITE_RESULTS+usage [ NO_PHYSICAL_NAMES ]
-///kw_pde+WRITE_RESULTS+detail When targetting the `.msh` output format, if `NO_PHYSICAL_NAMES` is given then the
+///kw_pde+WRITE_RESULTS+detail When targeting the `.msh` output format, if `NO_PHYSICAL_NAMES` is given then the
 ///kw_pde+WRITE_RESULTS+detail section that sets the actual names of the physical entities is not written.      
 ///kw_pde+WRITE_RESULTS+detail This might be needed in some cases to avoid name clashes when dealing with multiple `.msh` files.
     } else if (strcasecmp(token, "NO_PHYSICAL_NAMES") == 0) {
@@ -3026,7 +3026,7 @@ int feenox_parse_problem(void) {
 
 #ifdef HAVE_PETSC
   if (feenox.pde.petscinit_called == PETSC_TRUE) {
-    feenox_push_error_message("ony one PROBLEM keyword allowed");
+    feenox_push_error_message("only one PROBLEM keyword allowed");
     return FEENOX_ERROR;    
   } 
   
@@ -3094,7 +3094,7 @@ int feenox_parse_problem(void) {
 ///kw_pde+PROBLEM+usage | DETECT_HANGING_NODES
 ///kw_pde+PROBLEM+detail If either `DETECT_HANGING_NODES` or `HANDLE_HANGING_NODES` are given, 
 ///kw_pde+PROBLEM+detail an intermediate check for nodes without any associated elements will be performed.
-///kw_pde+PROBLEM+detail For well-behaved meshes this check is redundant so by detault it is not done (`DO_NOT_DETEC_HANGING_NODES`).
+///kw_pde+PROBLEM+detail For well-behaved meshes this check is redundant so by default it is not done (`DO_NOT_DETEC_HANGING_NODES`).
 ///kw_pde+PROBLEM+detail With `DETECT_HANGING_NODES`, FeenoX will report the tag of the hanging nodes and stop.
     } else if (strcasecmp(token, "DETECT_HANGING_NODES") == 0) {
       feenox.pde.hanging_nodes = hanging_nodes_detect;
@@ -3105,7 +3105,7 @@ int feenox_parse_problem(void) {
  
      
 ///kw_pde+PROBLEM+usage [ DETECT_UNRESOLVED_BCS
-///kw_pde+PROBLEM+detail By default, FeenoX checks that all physical groups referred to in the `BC` keywors exists (`DETECT_UNRESOLVED_BCS`).
+///kw_pde+PROBLEM+detail By default, FeenoX checks that all physical groups referred to in the `BC` keywords exists (`DETECT_UNRESOLVED_BCS`).
     } else if (strcasecmp(token, "DETECT_UNRESOLVED_BCS") == 0) {
       feenox.pde.unresolved_bcs = unresolved_bcs_detect;
 ///kw_pde+PROBLEM+usage | ALLOW_UNRESOLVED_BCS ]@

--- a/src/pdes/gradient.c
+++ b/src/pdes/gradient.c
@@ -230,7 +230,7 @@ int feenox_problem_gradient_compute_at_element(element_t *e, mesh_t *mesh) {
       
       } else {
         
-        // direct evalution at the nodes
+        // direct evaluation at the nodes
         gsl_matrix *B = feenox_fem_compute_B(e, e->type->node_coords[j]);
       
         // the derivatives of each dof g with respect to the coordinate mas nueve derivadas (o menos)

--- a/src/pdes/init.c
+++ b/src/pdes/init.c
@@ -402,7 +402,7 @@ int feenox_problem_init_runtime_general(void) {
   
   // command-line arguments take precedence over the options in the input file
   // so we have to read them here and overwrite what he have so far
-  // recall that we alreay stripped off one dash from the original argv array
+  // recall that we already stripped off one dash from the original argv array
 
   PetscBool flag = PETSC_FALSE;
   

--- a/src/pdes/mechanical/bc.c
+++ b/src/pdes/mechanical/bc.c
@@ -354,7 +354,7 @@ int feenox_problem_bc_set_mechanical_traction(bc_data_t *this, element_t *e, uns
 
   // TODO: set all the DOFs at the same time
   double t[3] = {0,0,0};
-  // TODO: wrap feenox_expression_eval() with vitrual methods according to the dependence of the bc
+  // TODO: wrap feenox_expression_eval() with virtual methods according to the dependence of the bc
   t[this->dof] = feenox_expression_eval(&this->expr);
 //  printf("%g\n", t[bc_data->dof]);
 //  feenox_call(feenox_problem_bc_natural_set(e, v, t));

--- a/src/pdes/modal/init.c
+++ b/src/pdes/modal/init.c
@@ -111,7 +111,7 @@ int feenox_problem_parse_time_init_modal(void) {
 ///va+M_T+desc \[ M_T = \frac{1}{n_\text{DOFs}} \cdot \vec{1}^T \cdot M \cdot \vec{1} \]
 ///va+M_T+desc 
 ///va+M_T+desc where $n_\text{DOFs}$ is the number of degrees of freedoms per node.
-///va+M_T+desc Note that this is only approximately equal to the actual mass whih is
+///va+M_T+desc Note that this is only approximately equal to the actual mass which is
 ///va+M_T+desc the integral of the density $\rho(x,y,z)$ over the problem domain.
   feenox_check_alloc(modal.M_T = feenox_define_variable_get_ptr("M_T"));
 

--- a/src/pdes/neutron_diffusion/init.c
+++ b/src/pdes/neutron_diffusion/init.c
@@ -313,7 +313,7 @@ int feenox_problem_setup_eps_neutron_diffusion(EPS eps) {
 
   petsc_call(EPSSetProblemType(eps, (neutron_diffusion.groups == 1) ? EPS_PGNHEP : EPS_GNHEP));
   
-  // we expect the eigenvalue to be near one and an absolute test is fater
+  // we expect the eigenvalue to be near one and an absolute test is faster
   petsc_call(EPSSetConvergenceTest(feenox.pde.eps, EPS_CONV_ABS));
   
   // offsets around one

--- a/src/pdes/neutron_sn/init.c
+++ b/src/pdes/neutron_sn/init.c
@@ -554,7 +554,7 @@ int feenox_problem_setup_eps_neutron_sn(EPS eps) {
   // generalized non-hermitian problem
   petsc_call(EPSSetProblemType(eps, EPS_GNHEP));
 
-  // we expect the eigenvalue to be near one and an absolute test is fater
+  // we expect the eigenvalue to be near one and an absolute test is faster
   petsc_call(EPSSetConvergenceTest(feenox.pde.eps, EPS_CONV_ABS));
   
   // offsets around one

--- a/src/pdes/reaction.c
+++ b/src/pdes/reaction.c
@@ -39,7 +39,7 @@ int feenox_instruction_reaction(void *arg) {
     feenox_check_alloc(node_index = calloc(feenox.pde.size_local, sizeof(PetscInt)));
     for (g = 0; g < feenox.pde.dofs; g++) {
       if (reaction->x0[g].items != NULL) {
-        // if an explcit coordinate was given, use it
+        // if an explicit coordinate was given, use it
         x0[g] = feenox_expression_eval(&reaction->x0[g]);
       } else {
         // use the COG

--- a/tests/2dpwr.fee
+++ b/tests/2dpwr.fee
@@ -19,7 +19,7 @@
 #           2. Two-dimensional (x,y)-geometry
 #
 PROBLEM neutron_diffusion 2D GROUPS 2
-DEFAULT_ARGUMENT_VALUE 1 quarter   # either quarter or eigth
+DEFAULT_ARGUMENT_VALUE 1 quarter   # either quarter or eighth
 READ_MESH 2dpwr-$1.msh
 
 # define materials and cross sections according to the two-group constants

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,7 +12,7 @@ The main objective is to detect regressions which might be introduced into the c
 
  * The test cases usually return a single number (which should be near zero) comparing the numerical result with the expected one.
  
- * These input files can also be used as a reference and/or examples of how to use a certain keyworkd. Just `grep` for the keyword over `*.fee` to see an example of usage:
+ * These input files can also be used as a reference and/or examples of how to use a certain keyword. Just `grep` for the keyword over `*.fee` to see an example of usage:
 
    ```terminal
    $ grep INTEGRATE *.fee

--- a/tests/U-235.fee
+++ b/tests/U-235.fee
@@ -1,6 +1,6 @@
 # material U-235 (tables 33 and 34)
 
-# NOTE: 1 is the slow energy grop and 2 is the fast energy group
+# NOTE: 1 is the slow energy group and 2 is the fast energy group
 
 # fast-energy group
 nu2_fuel = 2.70

--- a/tests/U-Al.fee
+++ b/tests/U-Al.fee
@@ -1,6 +1,6 @@
 # material U-Al (tables 36 and 37)
 
-# NOTE: 1 is the slow energy grop and 2 is the fast energy group
+# NOTE: 1 is the slow energy group and 2 is the fast energy group
 
 # fast-energy group
 nu2_fuel = 0

--- a/tests/URRa.fee
+++ b/tests/URRa.fee
@@ -1,6 +1,6 @@
 # material U-235 (tables 52 and 53)
 
-# NOTE: 1 is the slow energy grop and 2 is the fast energy group
+# NOTE: 1 is the slow energy group and 2 is the fast energy group
 # NOTE: this material has anisotropic scattering
 
 # fast-energy group

--- a/tests/bunny-thermal-mpi.sh
+++ b/tests/bunny-thermal-mpi.sh
@@ -27,7 +27,7 @@ for n in $(seq 1 4); do
   exitifwrong $?
 done
 
-# this input file reads bunny.msh that doest not have partitions
+# this input file reads bunny.msh that does not have partitions
 for n in $(seq 1 4); do
   answerzerompi ${n} bunny-thermal.fee 1e-2
   exitifwrong $?

--- a/tests/exp.fee
+++ b/tests/exp.fee
@@ -1,6 +1,6 @@
 PHASE_SPACE x   # variable x is in the phase space of the DAE system
 end_time = 1    # time goes from 0 to 1
-x_0 = 1         # initial codition is x = 1 for t = 0
+x_0 = 1         # initial condition is x = 1 for t = 0
 x_dot = -x      # differential equation
 # output time, x, the analytical solution and the absolute error
 # PRINT %.6f t x exp(-t) %e abs(x-exp(-t))      

--- a/tests/inverse-integral.fee
+++ b/tests/inverse-integral.fee
@@ -3,7 +3,7 @@ FUNCTION flux(t) FILE flux.dat
 
 VAR t'   # dummy integration variable
 
-# define a flux function that allos for negative times
+# define a flux function that allows for negative times
 flux_a = vec_flux_t[1]
 flux_b = vec_flux_t[vecsize(vec_flux)]
 phi(t) := if(t<flux_a, flux(flux_a), flux(t))

--- a/tests/lag.fee
+++ b/tests/lag.fee
@@ -12,7 +12,7 @@ tau = 1.234
 # signal r is equal to zero except for a < t < b
 r = heaviside(t-a)-heaviside(t-b)
 
-# signal y is equal to signal r fitered through a lag
+# signal y is equal to signal r filtered through a lag
 # of characteristic time tau
 y = lag(r, tau)
 

--- a/tests/mms/thermal/2d/README.md
+++ b/tests/mms/thermal/2d/README.md
@@ -69,7 +69,7 @@ By default this will run over a few combinations of
    - struct
    - frontal
    - dealaunay
- * refinement factors $c$ such that the mesh size $h$ is propotional to $1/c$,
+ * refinement factors $c$ such that the mesh size $h$ is proportional to $1/c$,
    - 4
    - 8
    - 12

--- a/tests/nafems/le10/unical1.c
+++ b/tests/nafems/le10/unical1.c
@@ -14,7 +14,7 @@
 * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 *****************************************************************************/
 /*
-This small program converts finite elemet meshes given in the SDRL universal
+This small program converts finite element meshes given in the SDRL universal
 file format into ABAQUS / Calculix compatible input decks. The format 
 of the universal data sets can be found at http://www.sdrl.uc.edu.
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.svg" -L argumentos,barrer,bu,datas,excede,fases,funcion,functinos,hace,pares,pres,prool,reste,ser,shepard,tawk,ue,vectores`